### PR TITLE
23 revamp various html tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `Auth\LoginHandler`.
+- Added new `HTMLElements` method `a` for inserting links.
 
 ### Changed
 
@@ -19,6 +20,10 @@
 
 - Fixed a bug with `HTML::p_container`.
 - Fixed a bug with header styles.
+
+### Deprecated
+
+- `HTMLElements` method `link`.
 
 ### Issues Closed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 
 - Fixed a bug with `HTML::p_container`.
+- Fixed a bug with header styles.
 
 ### Issues Closed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `Auth\LoginHandler`.
 - Added new `HTMLElements` method `a` for inserting links.
+- Added method `file_exists` to `FileSystem`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 - Added `Auth\LoginHandler`.
 
+### Changed
+
+- Extended the following to `HTML\HTMLMeta`: #23
+  - `HTML\Buttons`
+  - `HTML\Draw`
+  - `HTML\Forms`
+  - `HTMLElements`
+  - `HTML\Scripts`
+
 ### Fixed
 
 - Fixed a bug with `HTML::p_container`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # CHANGELOG
 
-## Version 0.1.6-beta - UNRELEASED
+## Version 0.1.6-beta - 2022-09-14
 
 ### Added
 
 - Added `Auth\LoginHandler`.
 - Added new `HTMLElements` method `a` for inserting links.
 - Added method `file_exists` to `FileSystem`.
+- Added a tool for inline setting echo for the specific object being drawn. #23
+- Added methods for more easily changing the value of `class::$echo`.
+- Added Exception Class `MethodNotFound`.
+- Added meta methods for rendering HTML elements and consolidated current methods into these methods. These methods are:
+  - `html_element_container`.
+  - `html_tag_open`.
+  - `html_tag_close`.
+  - `assign_key_values`.
 
 ### Changed
 
@@ -28,7 +36,7 @@
 
 ### Issues Closed
 
-- #23 WIP
+- #23
 
 ---
 

--- a/src/DevTools/Dashboard.php
+++ b/src/DevTools/Dashboard.php
@@ -79,7 +79,7 @@ class Dashboard extends ConnectMySQL {
         }
         Button::general( [
             'content' => 'Exit',
-            'href'    => 'home',
+            'link'    => 'home',
         ] );
         HTML::close_div();
     }
@@ -114,7 +114,7 @@ class Dashboard extends ConnectMySQL {
         Draw::set_input_multi_line();
         Button::general( [
             'content' => 'Create Table Tools from Table',
-            'href'    => '?dev-page=table-tool-creator',
+            'link'    => '?dev-page=table-tool-creator',
         ] );
         Draw::close_multi_line_input();
     }
@@ -188,7 +188,7 @@ class Dashboard extends ConnectMySQL {
 
         Draw::lines( 2 );
         Draw::line_separator();
-        Button::back( ['href' => '@dev-tools'] );
+        Button::back( ['link' => '@dev-tools'] );
     }
 
 }

--- a/src/Errors/MethodNotFound.php
+++ b/src/Errors/MethodNotFound.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace LBF\Errors;
+
+use Exception;
+use Throwable;
+
+/**
+ * Error page for handling errors when a called class method does not exist.
+ * 
+ * use LBF\Errors\MethodNotFound;
+ * 
+ * @author  Gareth Palmer   [Github & Gitlab /projector22]
+ * @since   LBF 0.1.6-beta
+ */
+
+class MethodNotFound extends Exception {
+
+    /**
+     * Class constructor.
+     * 
+     * @param   string          $message — [optional] The Exception message to throw.
+     * @param   int             $code — [optional] The Exception code.
+     * @param   Throwable|null  $previous [optional] The previous throwable used for the exception chaining.
+     * 
+     * @return  never
+     * 
+     * @access  public
+     * @since   LBF 0.1.6-beta
+     */
+
+    public function __construct( $message, $code = 0, Throwable $previous = null ) {
+        parent::__construct( $message, $code, $previous );
+    }
+}

--- a/src/HTML/Buttons.php
+++ b/src/HTML/Buttons.php
@@ -583,10 +583,9 @@ class Buttons extends HTMLMeta {
             $params['class'] = "reg_submit_bttn";
         }
 
-        $hold = self::$echo;
-        self::$echo = false;
+        $hold = self::temporary_change_echo( false );
         $button .= self::general( $params );
-        self::$echo = $hold;
+        self::restore_origonal_echo( $hold );
 
         $button .= "</div>"; // floaty_submit
 
@@ -608,8 +607,7 @@ class Buttons extends HTMLMeta {
             return;
         }
         HTML::div( ['class' => 'floating_tb_buttons_contain'] );
-        $hold = JS::$echo;
-        JS::$echo = false;
+        $hold = JS::temporary_change_echo( false );
 
         /**
          * The JS which handles the buttons going up & down.
@@ -640,7 +638,7 @@ class Buttons extends HTMLMeta {
             JS::script_module( $js( 'ftb_down' ) ) . $icon->get( 'chevrons-down', echo: false )
         );
 
-        JS::$echo = $hold;
+        JS::restore_origonal_echo( $hold );
         HTML::close_div(); // floating_tb_buttons_contain
     }
 
@@ -683,10 +681,10 @@ class Buttons extends HTMLMeta {
         } else {
             $params['class'] = 'interface_button ' . self::$interface_bttn_class;
         }
-        $hold = HTML::$echo;
-        HTML::$echo = false;
+
+        $hold = HTML::temporary_change_echo( false );
         $button .= HTML::link( $link, $button_text, $params );
-        HTML::$echo = $hold;
+        HTML::restore_origonal_echo( $hold );
         $button .= "</div>";
         self::handle_echo( $button );
         return $button;

--- a/src/HTML/Buttons.php
+++ b/src/HTML/Buttons.php
@@ -7,6 +7,7 @@ use Feather\Icons;
 use LBF\Auth\Hash;
 use LBF\HTML\JS;
 use LBF\HTML\HTML;
+use LBF\HTML\HTMLMeta;
 
 /**
  * This class is to draw out various buttons on the page.
@@ -16,23 +17,12 @@ use LBF\HTML\HTML;
  * @author  Gareth Palmer   [Github & Gitlab /projector22]
  * 
  * @since   LRS 3.11.0
- * @since   LRS 3.28.0  Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
- *                  Namespace changed from `Framework` to `LBF`.
+ * @since   LRS 3.28.0      Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
+ *                          Namespace changed from `Framework` to `LBF`.
+ * @since   LBF 0.1.6-beta  Added extension `HTMLMeta`.
  */
 
-class Buttons {
-
-    /**
-     * Whether to echo or return the string item
-     * 
-     * @var boolean $echo   Default: true
-     * 
-     * @since   LRS 3.6.0
-     * @since   LRS 3.11.0  Moved to LBF\HTML\Buttons.php from PageElements.php
-     */
-
-    public static bool $echo = true;
-
+class Buttons extends HTMLMeta {
 
     /**
      * Handle the creation of assigned class names to the button element.
@@ -41,6 +31,7 @@ class Buttons {
      * 
      * @return  array   $params     The modified params.
      * 
+     * @static
      * @access  private
      * @since   LRS 3.16.1
      */
@@ -90,6 +81,7 @@ class Buttons {
      * 
      * @return  string   $params     The container.
      * 
+     * @static
      * @access  private
      * @since   LRS 3.16.1
      */
@@ -134,15 +126,16 @@ class Buttons {
      * @param   array   $params     Any elements to be added to the button.
      *                              Default: []
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      * @since   LRS 3.11.0  Moved to LBF\HTML\Buttons.php from PageElements.php. Renamed to general() from custom_button()
      * @since   LRS 3.16.1  Revamped completely, now the base of almost all buttons. Removed params $content, $overwrite_class
      */
 
-    public static function general( array $params = [] ) {
+    public static function general( array $params = [] ): string {
         if ( !isset( $params['content'] ) ) {
             throw new \Exception( "Button \$param attribute 'content' has not been set. \$paramT['content'] must be set." );
         }
@@ -150,12 +143,12 @@ class Buttons {
             'content', 'container', 'inline', 'padding', 'hidden',
             'linebreak', 'colour', 'color', 'new_tab', 'reload',
             'tab',
-            // 'label', 'hint', 
+            // 'label', 'hint',
             /**
-             * @todo    Would like to add above but not sure how to do without 
+             * @todo    Would like to add above but not sure how to do without
              *          breaking inline integrity
              */
-            
+
         ];
         $item = '';
 
@@ -244,11 +237,8 @@ class Buttons {
             $item .= "<div class='btn_lb'></div>";
         }
 
-        if ( self::$echo ) {
-            echo $item;
-        } else {
-            return $item;
-        }
+        self::handle_echo( $item );
+        return $item;
     }
 
 
@@ -262,6 +252,7 @@ class Buttons {
      * 
      * @return  string
      * 
+     * @static
      * @access  private
      * @since   LRS 3.16.1
      */
@@ -293,22 +284,19 @@ class Buttons {
      * 
      * @param   array   $params     Any elements to be added to the button.
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      * @since   LRS 3.11.0  Moved to LBF\HTML\Buttons.php from PageElements.php. Renamed to apply() from apply_button()
      * @since   LRS 3.16.1  Removed param $overwrite_class
      */
 
-    public static function apply( array $params ) {
+    public static function apply( array $params ): string {
         $button = self::do_button( $params, 'Apply', 'green' );
-
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        }
+        self::handle_echo( $button );
+        return $button;
     }
 
 
@@ -317,21 +305,18 @@ class Buttons {
      * 
      * @param   array   $params     Any elements to be added to the button.
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.13.0
      * @since   LRS 3.16.1  Removed param $overwrite_class
      */
 
-    public static function edit( array $params ) {
+    public static function edit( array $params ): string {
         $button = self::do_button( $params, 'Edit' );
-
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        }
+        self::handle_echo( $button );
+        return $button;
     }
 
 
@@ -342,8 +327,9 @@ class Buttons {
      * 
      * @param   array   $params     Any elements to be added to the button.
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.4.0
      * @since   LRS 3.6.0     Added param $id
@@ -351,14 +337,10 @@ class Buttons {
      * @since   LRS 3.13.0    Removed params $onclick, $id, added param $params - largely rewritten
      */
 
-    public static function save( array $params ) {
+    public static function save( array $params ): string {
         $button = self::do_button( $params, 'Save', 'green' );
-
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        }
+        self::handle_echo( $button );
+        return $button;
     }
 
 
@@ -367,13 +349,14 @@ class Buttons {
      * 
      * @param   array   $params     Any elements to be added to the button.
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.16.1
      */
 
-    public static function ok( array $params ) {
+    public static function ok( array $params ): string {
         if ( isset( $params['reload'] ) && $params['reload' ] ) {
             if ( !isset( $params['padding'] ) ) {
                 $params['padding'] = false;
@@ -383,12 +366,8 @@ class Buttons {
             }
         }
         $button = self::do_button( $params, 'OK', 'green' );
-
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        } 
+        self::handle_echo( $button );
+        return $button;
     }
 
 
@@ -397,21 +376,18 @@ class Buttons {
      * 
      * @param   array   $params     Any elements to be added to the button.
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.16.1
      */
 
-    public static function search( array $params ) {
+    public static function search( array $params ): string {
         $icon = new Icons;
         $button = self::do_button( $params, $icon->get( 'search', echo: false ) );
-
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        } 
+        self::handle_echo( $button );
+        return $button;
     }
 
 
@@ -422,8 +398,9 @@ class Buttons {
      * @param   boolean $print_dailogue Whether or not to use window.print().
      *                                  Default: true
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.3.2
      * @since   LRS 3.11.0  Moved to LBF\HTML\Buttons.php from PageElements.php. Renamed to print() from print_button()
@@ -431,7 +408,7 @@ class Buttons {
      * @since   LRS 3.16.1  Revamped and turned into a simple button.
      */
 
-    public static function print( array $params, bool $print_dailogue = false ) {
+    public static function print( array $params, bool $print_dailogue = false ): string {
         if ( $print_dailogue ) {
             if ( isset( $params['onclick'] ) ) {
                 $params['onclick'] .= " window.print()";
@@ -442,11 +419,8 @@ class Buttons {
         $icon = new Icons;
         $button = self::do_button( $params, $icon->get( 'printer', echo: false ) );
 
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        } 
+        self::handle_echo( $button );
+        return $button;
     }
 
 
@@ -455,15 +429,16 @@ class Buttons {
      * 
      * @param   array   $params     Any elements to be added to the button.
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      * @since   LRS 3.11.0  Moved to LBF\HTML\Buttons.php from PageElements.php. Renamed to reset() from reset_button()
      * @since   LRS 3.16.1  Completely reworked to use new button methods.
      */
 
-    public static function reset( array $params = [] ) {
+    public static function reset( array $params = [] ): string {
         $tab = isset ( $params['tab'] ) ? "&t={$params['tab']}" : '';
         if ( isset ( $params['onclick'] ) ) {
             $params['onclick'] .= " window.location.search=`?p={$_GET['p']}{$tab}`";
@@ -472,11 +447,8 @@ class Buttons {
         }
         $button = self::do_button( $params, 'Reset', 'blue' );
 
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        } 
+        self::handle_echo( $button );
+        return $button;
     }
 
 
@@ -486,13 +458,14 @@ class Buttons {
      * @param   array   $params     The params to be added to the button
      * @param   string  $content    The text on the button, if not overwritten.
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  private
      * @since   LRS 3.16.1
      */
 
-    private static function go_to_button_template( array $params, string $content ) {
+    private static function go_to_button_template( array $params, string $content ): string {
         if ( !isset( $params['href'] ) ) {
             throw new \Exception( "Button \$param attribute 'href' has not been set. \$paramT['href'] must be set." );
         }
@@ -531,21 +504,19 @@ class Buttons {
      * 
      * @param   string  $loc    The location to which the button must point
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @since   LRS 3.1.0
      * @since   LRS 3.6.0   Removed @param $class as this is moved to self::$button_class
      * @since   LRS 3.11.0  Moved to LBF\HTML\Buttons.php from PageElements.php. Renamed to back() from back_button()
      * @since   LRS 3.16.1  Rewritten to use the new button method.
      */
 
-    public static function back( array $params ) {
+    public static function back( array $params ): string {
         $button = self::go_to_button_template( $params, 'Back' );
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        }
+        self::handle_echo( $button );
+        return $button;
     }
 
 
@@ -556,34 +527,33 @@ class Buttons {
      * 
      * @param   string  $loc    The location to which the button must point
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @since   LRS 3.7.6
      * @since   LRS 3.11.0  Moved to LBF\HTML\Buttons.php from PageElements.php. Renamed to cancel() from cancel_button()
      * @since   LRS 3.16.1  Rewritten to use the new button method.
      */
-    
-    public static function cancel( array $params ) {
+
+    public static function cancel( array $params ): string {
         if ( !isset( $params['colour'] ) ) {
             $params['colour'] = 'blue';
         }
         $button = self::go_to_button_template( $params, 'Cancel' );
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        }
+        self::handle_echo( $button );
+        return $button;
     }
 
 
     /**
-     * Draw the floating submit button
+     * Draw the floating submit button.
      * 
      * @param   array   $params     Any elements to be added to the button.
      *                              Default: []
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @since   LRS 3.4.12
      * @since   LRS 3.9.0   Added @params $button_type & $onClick
      * @since   LRS 3.11.0  Moved to LBF\HTML\Buttons.php from PageElements.php. Renamed to floating_submit() from floating_submit_button()
@@ -591,7 +561,7 @@ class Buttons {
      * @since   LRS 3.16.1  Reworked again, moved to new button standard - removed params $button_type_submit, $overwrite_class
      */
 
-    public static function floating_submit( array $params = [] ) {
+    public static function floating_submit( array $params = [] ): string {
         $button = '';
         if ( !is_apple_mobile() ) {
             $button .= "<div class='floaty_submit text_align_center' id='floaty_submit'>";
@@ -620,17 +590,15 @@ class Buttons {
 
         $button .= "</div>"; // floaty_submit
 
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        }
+        self::handle_echo( $button );
+        return $button;
     }
 
 
     /**
      * Draw the floating top and bottom buttons
      * 
+     * @static
      * @since   LRS 3.6.0
      * @since   LRS 3.11.0  Moved to LBF\HTML\Buttons.php from PageElements.php.
      */
@@ -663,12 +631,12 @@ class Buttons {
         $icon = new Icons;
 
         HTML::div_container(
-            ['class' => 'ftb_button', 'id' => 'ftb_up'], 
+            ['class' => 'ftb_button', 'id' => 'ftb_up'],
             JS::script_module( $js( 'ftb_up' ) ) . $icon->get( 'chevrons-up', echo: false )
         );
 
         HTML::div_container(
-            ['class' => 'ftb_button', 'id' => 'ftb_down'], 
+            ['class' => 'ftb_button', 'id' => 'ftb_down'],
             JS::script_module( $js( 'ftb_down' ) ) . $icon->get( 'chevrons-down', echo: false )
         );
 
@@ -684,6 +652,7 @@ class Buttons {
      * 
      * @var string  $interface_bttn_class   Default: 'bttn'
      * 
+     * @static
      * @since   LRS 3.9.0
      * @since   LRS 3.11.0  Moved to LBF\HTML\Buttons.php from PageElements.php.
      */
@@ -693,19 +662,20 @@ class Buttons {
     /**
      * Draw a menu button
      * 
-     * @param   string  $button_text    The text which to draw
-     * @param   string  $link           The link to put on the button
-     * @param   array   $params         Any extra parameters to add to the 
+     * @param   string  $button_text    The text which to draw.
+     * @param   string  $link           The link to put on the button.
+     * @param   array   $params         Any extra parameters to add to the button.
      *                                  Default: null
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @since   LRS 3.9.0
      * @since   LRS 3.11.0  Moved to LBF\HTML\Buttons.php from PageElements.php. Renamed to interface() from interface_button()
      * @since   LRS 3.13.0  Revamped and removed params, $onclick, $extra_class, $id, added $params
      */
 
-    public static function interface( string $button_text, string $link, array $params = [] ) {
+    public static function interface( string $button_text, string $link, array $params = [] ): string {
         $button = '';
         $button .= "<div class='general_button'>";
         if ( isset( $params['class'] ) && $params['class'] != '' ) {
@@ -718,11 +688,8 @@ class Buttons {
         $button .= HTML::link( $link, $button_text, $params );
         HTML::$echo = $hold;
         $button .= "</div>";
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        }
+        self::handle_echo( $button );
+        return $button;
     }
 
 
@@ -731,24 +698,22 @@ class Buttons {
      * 
      * @param   array   $params     All the fields to put onto the button
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.12.8
      */
 
-    public static function login_eye( array $params = [] ) {
+    public static function login_eye( array $params = [] ): string {
         $button = '<button';
         foreach ( $params as $index => $value ) {
             $button .= " {$index}='{$value}'";
         }
         $icon = new Icons;
         $button .= '>' . $icon->get( 'eye-off', echo: false ) . '</button>';
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        }
+        self::handle_echo( $button );
+        return $button;
     }
 
 
@@ -763,18 +728,16 @@ class Buttons {
      * 
      * @return  string|void
      * 
+     * @static
      * @access  public
      * @since   LRS 3.13.0
      */
 
-    public static function link_button ( string $text, array $params = [], string $function = 'void(0)' ) {
+    public static function link_button ( string $text, array $params = [], string $function = 'void(0)' ): string {
         $button = HTML::link( "javascript:{$function}", $text, $params );
 
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        }
+        self::handle_echo( $button );
+        return $button;
     }
 
 }

--- a/src/HTML/Buttons.php
+++ b/src/HTML/Buttons.php
@@ -202,40 +202,7 @@ class Buttons extends HTMLMeta {
 
         $params['content'] = "<span id='{$params['id']}__spinner'></span>" . $params['content'];
 
-
         $item .= self::html_element_container( 'button', $params, $skip_fields );
-
-        // /**
-        //  * BUTTON
-        //  */
-        // $item .= "<button";
-
-        // foreach ( $params as $field => $value ) {
-        //     if ( in_array( $field, $skip_fields ) ) {
-        //         continue;
-        //     }
-        //     switch ( $field ) {
-        //         case 'autofocus':
-        //             $item .= $value ? ' autofocus' : '';
-        //             break;
-        //         case 'disabled':
-        //             $item .= $value ? ' disabled' : '';
-        //             break;
-        //         case 'href':
-        //             if ( isset( $params['new_tab'] ) && $params['new_tab'] ) {
-        //                 $item .= " onClick='javascript:window.open(\"{$value}\", \"_blank\")'";
-        //             } else {
-        //                 $item .= " onClick='window.location.href = \"{$value}\"'";
-        //             }
-        //             break;
-        //         default:
-        //             $item .= " {$field}='{$value}'";
-        //     }
-        // }
-
-        // $item .= ">";
-        // $item .= "<span id='{$params['id']}__spinner'></span>";
-        // $item .= "{$params['content']}</button>";
 
         if ( !$container['overwrite'] ) {
             $item .= "</$container_tag>";
@@ -468,6 +435,8 @@ class Buttons extends HTMLMeta {
      * 
      * @return  string
      * 
+     * @throws  MissingRequiredInputException   When `$params['href']` is missing.
+     * 
      * @static
      * @access  private
      * @since   LRS 3.16.1
@@ -475,7 +444,7 @@ class Buttons extends HTMLMeta {
 
     private static function go_to_button_template( array $params, string $content ): string {
         if ( !isset( $params['href'] ) ) {
-            throw new \Exception( "Button \$param attribute 'href' has not been set. \$paramT['href'] must be set." );
+            throw new MissingRequiredInputException( "Button \$param attribute 'href' has not been set. \$paramT['href'] must be set." );
         }
         $button = '';
 
@@ -689,9 +658,13 @@ class Buttons extends HTMLMeta {
         } else {
             $params['class'] = 'interface_button ' . self::$interface_bttn_class;
         }
+        $params['href'] = $link;
+        $params['text'] = $button_text;
 
         $hold = HTML::temporary_change_echo( false );
-        $button .= HTML::link( $link, $button_text, $params );
+
+        $button .= HTML::a( $params );
+        // $button .= HTML::link( $link, $button_text, $params );
         HTML::restore_origonal_echo( $hold );
         $button .= "</div>";
         self::handle_echo( $button );

--- a/src/HTML/Buttons.php
+++ b/src/HTML/Buttons.php
@@ -660,12 +660,13 @@ class Buttons extends HTMLMeta {
         }
         $params['href'] = $link;
         $params['text'] = $button_text;
+        $params['echo'] = false;
 
-        $hold = HTML::temporary_change_echo( false );
+        // $hold = HTML::temporary_change_echo( false );
 
         $button .= HTML::a( $params );
         // $button .= HTML::link( $link, $button_text, $params );
-        HTML::restore_origonal_echo( $hold );
+        // HTML::restore_origonal_echo( $hold );
         $button .= "</div>";
         self::handle_echo( $button );
         return $button;

--- a/src/HTML/Buttons.php
+++ b/src/HTML/Buttons.php
@@ -2,9 +2,9 @@
 
 namespace LBF\HTML;
 
-use Exception;
 use Feather\Icons;
 use LBF\Auth\Hash;
+use LBF\Errors\InvalidInputException;
 use LBF\Errors\MissingRequiredInputException;
 use LBF\HTML\JS;
 use LBF\HTML\HTML;
@@ -31,6 +31,8 @@ class Buttons extends HTMLMeta {
      * @param   array   $params     The params parsed on the button.
      * 
      * @return  array   $params     The modified params.
+     * 
+     * @throws  InvalidInputException   If a button colour value is invalid.
      * 
      * @static
      * @access  private
@@ -60,7 +62,7 @@ class Buttons extends HTMLMeta {
 
         if ( isset( $params['colour'] ) && $params['colour'] !== 'default' ) {
             if ( !in_array( $params['colour'], $permitted_colours ) ) {
-                throw new Exception( 'Button colour selected is not a permitted colour' );
+                throw new InvalidInputException( 'Button colour selected is not a permitted colour' );
             }
             $default_class .= " button_colour__{$params['colour']} coloured_button" ;
         }
@@ -662,11 +664,7 @@ class Buttons extends HTMLMeta {
         $params['text'] = $button_text;
         $params['echo'] = false;
 
-        // $hold = HTML::temporary_change_echo( false );
-
         $button .= HTML::a( $params );
-        // $button .= HTML::link( $link, $button_text, $params );
-        // HTML::restore_origonal_echo( $hold );
         $button .= "</div>";
         self::handle_echo( $button );
         return $button;
@@ -714,7 +712,9 @@ class Buttons extends HTMLMeta {
      */
 
     public static function link_button ( string $text, array $params = [], string $function = 'void(0)' ): string {
-        $button = HTML::link( "javascript:{$function}", $text, $params );
+        $params['href'] = "javascript:{$function}";
+        $params['text'] = $text;
+        $button = HTML::a( $params );
 
         self::handle_echo( $button );
         return $button;

--- a/src/HTML/Buttons.php
+++ b/src/HTML/Buttons.php
@@ -115,8 +115,8 @@ class Buttons extends HTMLMeta {
      * - *linebreak* - Whether to put in a linebreak before or after. Options are **'before'** or **'after'**.
      * - *colour*    - The colour of the button. See below for available colours.
      * - *color*     - Same as *colour*; see above.
-     * - *href*      - Navigate to this URI, if desired.
-     * - *new_tab*   - If an *href* is set, add the option to make the click load a new page. Options are boolean.
+     * - *link*      - Navigate to this URI, if desired.
+     * - *new_tab*   - If a *link* is set, add the option to make the click load a new page. Options are boolean.
      * - *reload*    - Add a JS script to make the button reload the page.
      * 
      * 
@@ -437,7 +437,7 @@ class Buttons extends HTMLMeta {
      * 
      * @return  string
      * 
-     * @throws  MissingRequiredInputException   When `$params['href']` is missing.
+     * @throws  MissingRequiredInputException   When `$params['link']` is missing.
      * 
      * @static
      * @access  private
@@ -445,8 +445,8 @@ class Buttons extends HTMLMeta {
      */
 
     private static function go_to_button_template( array $params, string $content ): string {
-        if ( !isset( $params['href'] ) ) {
-            throw new MissingRequiredInputException( "Button \$param attribute 'href' has not been set. \$paramT['href'] must be set." );
+        if ( !isset( $params['link'] ) ) {
+            throw new MissingRequiredInputException( "Button \$param attribute 'link' has not been set. \$paramT['link'] must be set." );
         }
         $button = '';
 

--- a/src/HTML/Buttons.php
+++ b/src/HTML/Buttons.php
@@ -5,6 +5,7 @@ namespace LBF\HTML;
 use Exception;
 use Feather\Icons;
 use LBF\Auth\Hash;
+use LBF\Errors\MissingRequiredInputException;
 use LBF\HTML\JS;
 use LBF\HTML\HTML;
 use LBF\HTML\HTMLMeta;
@@ -128,6 +129,8 @@ class Buttons extends HTMLMeta {
      * 
      * @return  string
      * 
+     * @throws  MissingRequiredInputException   Required param 'content' missing.
+     * 
      * @static
      * @access  public
      * @since   LRS 3.6.0
@@ -137,7 +140,7 @@ class Buttons extends HTMLMeta {
 
     public static function general( array $params = [] ): string {
         if ( !isset( $params['content'] ) ) {
-            throw new \Exception( "Button \$param attribute 'content' has not been set. \$paramT['content'] must be set." );
+            throw new MissingRequiredInputException( "Button \$param attribute 'content' has not been set. \$paramT['content'] must be set." );
         }
         $skip_fields = [
             'content', 'container', 'inline', 'padding', 'hidden',
@@ -197,37 +200,42 @@ class Buttons extends HTMLMeta {
          */
         $params = self::set_button_class( $params );
 
-        /**
-         * BUTTON
-         */
-        $item .= "<button";
+        $params['content'] = "<span id='{$params['id']}__spinner'></span>" . $params['content'];
 
-        foreach ( $params as $field => $value ) {
-            if ( in_array( $field, $skip_fields ) ) {
-                continue;
-            }
-            switch ( $field ) {
-                case 'autofocus':
-                    $item .= $value ? ' autofocus' : '';
-                    break;
-                case 'disabled':
-                    $item .= $value ? ' disabled' : '';
-                    break;
-                case 'href':
-                    if ( isset( $params['new_tab'] ) && $params['new_tab'] ) {
-                        $item .= " onClick='javascript:window.open(\"{$value}\", \"_blank\")'";
-                    } else {
-                        $item .= " onClick='window.location.href = \"{$value}\"'";
-                    }
-                    break;
-                default:
-                    $item .= " {$field}='{$value}'";
-            }
-        }
 
-        $item .= ">";
-        $item .= "<span id='{$params['id']}__spinner'></span>";
-        $item .= "{$params['content']}</button>";
+        $item .= self::html_element_container( 'button', $params, $skip_fields );
+
+        // /**
+        //  * BUTTON
+        //  */
+        // $item .= "<button";
+
+        // foreach ( $params as $field => $value ) {
+        //     if ( in_array( $field, $skip_fields ) ) {
+        //         continue;
+        //     }
+        //     switch ( $field ) {
+        //         case 'autofocus':
+        //             $item .= $value ? ' autofocus' : '';
+        //             break;
+        //         case 'disabled':
+        //             $item .= $value ? ' disabled' : '';
+        //             break;
+        //         case 'href':
+        //             if ( isset( $params['new_tab'] ) && $params['new_tab'] ) {
+        //                 $item .= " onClick='javascript:window.open(\"{$value}\", \"_blank\")'";
+        //             } else {
+        //                 $item .= " onClick='window.location.href = \"{$value}\"'";
+        //             }
+        //             break;
+        //         default:
+        //             $item .= " {$field}='{$value}'";
+        //     }
+        // }
+
+        // $item .= ">";
+        // $item .= "<span id='{$params['id']}__spinner'></span>";
+        // $item .= "{$params['content']}</button>";
 
         if ( !$container['overwrite'] ) {
             $item .= "</$container_tag>";

--- a/src/HTML/Draw.php
+++ b/src/HTML/Draw.php
@@ -6,6 +6,7 @@ use Feather\Icons;
 use LBF\HTML\JS;
 use LBF\Auth\Hash;
 use LBF\HTML\HTML;
+use LBF\HTML\HTMLMeta;
 use LBF\Img\SVGImages;
 use SVGTools\SVG;
 
@@ -19,44 +20,35 @@ use SVGTools\SVG;
  * @author  Gareth Palmer  [Github & Gitlab /projector22]
  * 
  * @since   LRS 3.1.0
- * @since   LRS 3.12.5  Moved to `Framework\HTML\Draw` from `PageElements`
- * @since   LRS 3.28.0  Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
- *                  Namespace changed from `Framework` to `LBF`.
+ * @since   LRS 3.12.5      Moved to `Framework\HTML\Draw` from `PageElements`
+ * @since   LRS 3.28.0      Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
+ *                          Namespace changed from `Framework` to `LBF`.
+ * @since   LBF 0.1.6-beta  Added extension `HTMLMeta`.
  */
 
-class Draw {
-
-    /**
-     * Whether to echo or return the string item
-     * 
-     * @var boolean $echo
-     * 
-     * @access  public
-     * @since   LRS 3.6.0
-     */
-
-    public static bool $echo = true;
-
+class Draw extends HTMLMeta {
 
     /**
      * Providing a spacing element as required
      * 
+     * @static
      * @access  public
      * @since   LRS 3.1.0
      */
 
     public static function element_spacer_one(): void {
-        echo "<span class='spacer_one'></span><span></span>";    
+        echo "<span class='spacer_one'></span><span></span>";
     }
 
 
     /**
      * Providing a spacing element as required
      * 
+     * @static
      * @access  public
      * @since   LRS 3.1.0
      */
-    
+
     public static function element_spacer_two(): void {
         echo "<span class='spacer_two'></span><span></span>";
     }
@@ -79,6 +71,7 @@ class Draw {
      * 
      * @param   int     $k  The number to draw  Default: 1
      * 
+     * @static
      * @access  public
      * @since   LRS 3.1.0
      */
@@ -99,8 +92,9 @@ class Draw {
      * 
      * @param   integer     $k  The number of lines to draw
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.1.0
      * @since   LRS 3.4.0   Added @param $inline
@@ -108,7 +102,7 @@ class Draw {
      * @since   LRS 3.14.0  Added a catch for CLI_INTERFACE
      */
 
-    public static function lines( int $k ) {
+    public static function lines( int $k ): string {
         if ( !isset( self::$cli ) ) {
             self::$cli = php_sapi_name() == 'cli';
         }
@@ -117,11 +111,9 @@ class Draw {
         for ( $i = 0; $i < $k; $i++ ) {
             $line .= $lb;
         }
-        if ( self::$echo ) {
-            echo $line;
-        } else {
-            return $line;
-        }
+
+        self::handle_echo( $line );
+        return $line;
     }
 
 
@@ -131,32 +123,32 @@ class Draw {
      * @param   integer     $k      Number of lines to draw.
      *                              Default: 1
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.17.4
      */
 
-    public static function line_separator( int $k = 1 ) {
+    public static function line_separator( int $k = 1 ): string {
         $line = '';
         for ( $i = 0; $i < $k; $i++ ) {
             $line .= '<hr>';
         }
-        if ( self::$echo ) {
-            echo $line;
-        } else {
-            return $line;
-        }
+
+        self::handle_echo( $line );
+        return $line;
     }
 
 
     /**
      * Draws a page break when printing
      * 
+     * @static
      * @access  public
      * @since   LRS 3.1.0
      */
-    
+
     public static function page_break(): void {
         echo "<div class='page_break'></div>";
     }
@@ -169,10 +161,11 @@ class Draw {
      * 
      * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.1.0
      */
-    
+
     public static function action_error( string $info = '' ): string {
         if ( $info == '' ) {
             $error = "An error has occured ";
@@ -187,56 +180,58 @@ class Draw {
 
 
     /**
-     * Draw out a <span> which is used in the description in an admin or discipline page element
+     * Draw out a <span> which is used in the description in an admin or discipline page element.
      * 
-     * @param   string  $input  The string to be displayed on the screen
-     * @param   int     $lines  The number of lines to be drawn before the text
+     * @param   string  $input  The string to be displayed on the screen.
+     * @param   int     $lines  The number of lines to be drawn before the text.
      *                          Default: 0
      * 
      * @return  string|void
      * 
+     * @static
      * @access  public
      * @since   LRS 3.1.0
-     * @since   LRS 3.6.0   Changed $lines default to 0
+     * @since   LRS 3.6.0       Changed $lines default to 0.
+     * @since   LBF 0.1.6-beta  Revamped.
      */
 
-    public static function item_description( string $input, int $lines = 0 ) {
-        if ( self::$echo ) {
-            self::lines( $lines );
-            echo "<span>{$input}</span>";
-        } else {
-            $element = self::lines( $lines );
-            $element .= "<span>{$input}</span>";
-            return $element;    
-        }
+    public static function item_description( string $input, int $lines = 0 ): string {
+        $hold = self::$echo;
+        self::$echo = false;
+        $element = self::lines( $lines ) . "<span>{$input}</span>";
+        self::$echo = $hold;
+        self::handle_echo( $element );
+        return $element;
     }
 
 
     /**
-     * Draw out a span which will be used to draw the response text from JS AJAX calls 
+     * Draw out a span which will be used to draw the response text from JS AJAX calls.
      * 
-     * @param   string  $id         Desired span id elemenet
-     * @param   string  $content    Content of the span element
+     * @param   string  $id         Desired span id elemenet.
+     * @param   string  $content    Content of the span element.
      * 
+     * @static
      * @access  public
      * @since   LRS 3.1.0
      */
 
     public static function response_text( string $id, string $content = '' ): void  {
-        echo "<span id='{$id}'>{$content}</span>"; 
+        echo "<span id='{$id}'>{$content}</span>";
     }
 
 
     /**
      * The text area containing some text to be copied.
      * 
-     * Note, if this is being loaded via AJAX, you will need to put the 
+     * Note, if this is being loaded via AJAX, you will need to put the
      * line `JS::clipboardButton();` into the host page, as the insert
      * here will not run via AJAX.
      * 
      * @param   string  $test   The text to be copied
      * @param   string  $id     The id of the input element to be copied
      * 
+     * @static
      * @access  public
      * @since   LRS 3.4.0
      */
@@ -257,6 +252,7 @@ class Draw {
      * 
      * @param   string  $text   The text to be drawn in the header
      * 
+     * @static
      * @access  public
      * @since   LRS 3.4.1
      */
@@ -273,6 +269,7 @@ class Draw {
      * 
      * @param   string  $id     Desired id of elemenet
      * 
+     * @static
      * @access  public
      * @since   LRS 3.4.1
      */
@@ -287,6 +284,7 @@ class Draw {
     /**
      * Add some CSS to force a page print to landscape
      * 
+     * @static
      * @access  public
      * @since   LRS 3.4.9
      */
@@ -310,12 +308,13 @@ class Draw {
      *                                  Default: null
      * @param   string  $content        The content to load into the box
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      * @since   LRS 3.14.0  Added param $content
      */
 
-    public static function code_feedback_box( string $id, ?string $custom_height = null, string $content = '' ) {
+    public static function code_feedback_box( string $id, ?string $custom_height = null, string $content = '' ): void {
         $params = ['class' => 'code_feedback_box', 'id' => $id];
         if ( !is_null( $custom_height ) ) {
             $params['style'] = "height: $custom_height";
@@ -329,6 +328,7 @@ class Draw {
      * 
      * @param   string  $header     The text to be displayed
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      */
@@ -343,6 +343,7 @@ class Draw {
      * 
      * @param   string  $page the page on the help form to go to
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      */
@@ -360,12 +361,13 @@ class Draw {
      * @param   boolean $line_break     Where or not to put in a line break
      *                                  Default: true
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      */
 
     public static function item_heading( string $text, bool $line_break = true ): void {
-        echo "<span class='item_heading'><b>$text</b></span>";
+        echo "<span class='item_heading'><b>{$text}</b></span>";
         if ( $line_break ) {
             self::lines( 1 );
         }
@@ -375,7 +377,7 @@ class Draw {
     /**
      * Display the item input inline (using flex)
      * 
-     * @var boolean $display_item_input_inline     
+     * @var boolean $display_item_input_inline
      * 
      * @access  public
      * @since   LRS 3.9.0
@@ -392,6 +394,7 @@ class Draw {
      * @param   string  $id             The id to give the span to be drawn
      *                                  Default: null
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      */
@@ -421,6 +424,7 @@ class Draw {
      * @param   string  $id             The id of the containing span. If you wish to do some Javascript on the element
      *                                  Default: null
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      * @since   LRS 3.8.0   Added @param $id
@@ -447,6 +451,7 @@ class Draw {
      * @param   boolean $line_break     Where or not to put in a line break
      *                                  Default: true
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      */
@@ -464,19 +469,17 @@ class Draw {
      * 
      * @param   string  $text          The text header
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      */
 
-    public static function item_description_header( string $text ) {
+    public static function item_description_header( string $text ): string {
         $h = "<h1>{$text}</h1>";
-        if ( self::$echo ) {
-            echo $h;
-        } else {
-            return $h;
-        }
+        self::handle_echo( $h );
+        return $h;
     }
 
 
@@ -487,24 +490,24 @@ class Draw {
      * @param   string  $size   The font size desired
      *                          Default: 12px
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      */
 
-    public static function custom_header( string $text, string $size = '12px' ) {
-        $div = "<div style='font-size: $size'>$text</div>";
-        if ( self::$echo ) {
-            echo $div;
-        } else {
-            return $div;
-        }
+    public static function custom_header( string $text, string $size = '12px' ): string {
+        $div = "<div style='font-size: {$size}'>{$text}</div>";
+        self::handle_echo( $div );
+        return $div;
     }
 
 
     /**
      * Draw the html elements to open a link in a new tab
+     * 
+     * @var string  NEW_TAB
      * 
      * @access  public
      * @since   LRS 3.7.1
@@ -514,11 +517,12 @@ class Draw {
 
 
     /**
-     * Draw the section break template
+     * Draw the section break template.
      * 
-     * @param   string  $description    The text to go into the description
-     * @param   string  $class          The class of the new element
+     * @param   string  $description    The text to go into the description.
+     * @param   string  $class          The class of the new element.
      * 
+     * @static
      * @access  private
      * @since   LRS 3.12.8
      */
@@ -538,6 +542,7 @@ class Draw {
      * 
      * @param   string  $description    The description to be placed in this section break
      * 
+     * @static
      * @access  public
      * @since   LRS 3.8.0
      */
@@ -553,6 +558,7 @@ class Draw {
      * @param   string  $group_name     The name to draw next to the toggle box
      * @param   string  $toggle         The toggle drawn from Form::toggle()
      * 
+     * @static
      * @access  public
      * @since   LRS 3.9.0
      */
@@ -573,6 +579,7 @@ class Draw {
      *                              $link format: PAGE . ?p=page&t=tab
      * @param   string  $default    The default tab, in case $_GET is not set
      * 
+     * @static
      * @access  public
      * @since   LRS 3.12.0
      */
@@ -597,6 +604,7 @@ class Draw {
      * 
      * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.14.0
      */
@@ -613,6 +621,7 @@ class Draw {
     /**
      * Text to put at the end of all scripts.
      * 
+     * @static
      * @access  public
      * @since   LRS 3.14.0
      */
@@ -625,8 +634,9 @@ class Draw {
     /**
      * Draw a draggable list
      * 
-     * @param   array   $data      The contents of each cell
+     * @param   array   $data   The contents of each cell
      * 
+     * @static
      * @access  public
      * @since   LRS 3.15.0
      */
@@ -645,12 +655,12 @@ class Draw {
         $svg = new SVG( SVGImages::grabber->image() );
         $svg->set_viewbox( 0, 0, 16, 16 );
         foreach ( $data as $item ) {
-            $line = HTML::div_container( 
-                ['class' => 'draggable_entry'], 
+            $line = HTML::div_container(
+                ['class' => 'draggable_entry'],
                 HTML::span_container(
-                    ['class' => 'de_item'], 
-                    $item 
-                ) . 
+                    ['class' => 'de_item'],
+                    $item
+                ) .
                 HTML::span_container(
                     ['class' => "de_grabber de_grabber{$id}"],
                     $svg->return(),
@@ -689,6 +699,7 @@ class Draw {
      * @param   array   $params     The params to add to the div.
      *                              Default: []
      * 
+     * @static
      * @access  public
      * @since   LRS 3.15.8
      */
@@ -720,6 +731,7 @@ class Draw {
      * @param   boolean $close_left_column  Whether or not to close the left hand column
      *                                      Default: true
      * 
+     * @static
      * @access  public
      * @since   LRS 3.15.8
      */
@@ -785,6 +797,7 @@ class Draw {
      * @param   array   $params     The params to add to the div.
      *                              Default: []
      * 
+     * @static
      * @access  public
      * @since   LRS 3.16.0
      */
@@ -807,6 +820,7 @@ class Draw {
     /**
      * Close the right / full length column
      * 
+     * @static
      * @access  public
      * @since   LRS 3.15.8
      */
@@ -819,6 +833,7 @@ class Draw {
     /**
      * Draw a number of input fields in a single line.
      * 
+     * @static
      * @access  public
      * @since   LRS 3.16.0
      */
@@ -831,6 +846,7 @@ class Draw {
     /**
      * End the line of input fields.
      * 
+     * @static
      * @access  public
      * @since   LRS 3.16.0
      */
@@ -843,6 +859,7 @@ class Draw {
     /**
      * Draw a filter container.
      * 
+     * @static
      * @access  public
      * @since   LRS 3.16.0
      */
@@ -855,6 +872,7 @@ class Draw {
     /**
      * End the line of table filter container.
      * 
+     * @static
      * @access  public
      * @since   LRS 3.16.0
      */
@@ -867,6 +885,7 @@ class Draw {
     /**
      * Draw an aligned left container.
      * 
+     * @static
      * @access  public
      * @since   LRS 3.16.0
      */
@@ -877,8 +896,9 @@ class Draw {
 
 
     /**
-     * End the blocks aligned left
+     * End the blocks aligned left.
      * 
+     * @static
      * @access  public
      * @since   LRS 3.16.0
      */

--- a/src/HTML/Draw.php
+++ b/src/HTML/Draw.php
@@ -196,10 +196,9 @@ class Draw extends HTMLMeta {
      */
 
     public static function item_description( string $input, int $lines = 0 ): string {
-        $hold = self::$echo;
-        self::$echo = false;
+        $hold = self::temporary_change_echo( false );
         $element = self::lines( $lines ) . "<span>{$input}</span>";
-        self::$echo = $hold;
+        self::restore_origonal_echo( $hold );
         self::handle_echo( $element );
         return $element;
     }
@@ -528,12 +527,11 @@ class Draw extends HTMLMeta {
      */
 
     private static function break_template( string $description, string $class ): void {
-        $hold = HTML::$echo;
-        HTML::$echo = true;
+        $hold = HTML::temporary_change_echo( true );
         HTML::close_div();
         HTML::div_container( ['class' => 'page_element_description'], $description );
         HTML::div( ['class' => $class] );
-        HTML::$echo = $hold;
+        HTML::restore_origonal_echo( $hold );
     }
 
 
@@ -642,8 +640,7 @@ class Draw extends HTMLMeta {
      */
 
     public static function draggable_list( array $data ): void {
-        $hold = HTML::$echo;
-        HTML::$echo = true;
+        $hold = HTML::temporary_change_echo( true );
         $id = Hash::random_id_string( 5 );
 
         HTML::div( [
@@ -689,7 +686,7 @@ class Draw extends HTMLMeta {
                 handle: '.de_grabber{$id}',
             });"
         );
-        HTML::$echo = $hold;
+        HTML::restore_origonal_echo( $hold );
     }
 
 
@@ -705,8 +702,7 @@ class Draw extends HTMLMeta {
      */
 
     public static function standard_column_left( array $params = [] ): void {
-        $hold = HTML::$echo;
-        HTML::$echo = true;
+        $hold = HTML::temporary_change_echo( true );
 
         if ( isset ( $params['class'] ) ) {
             $params['class'] = 'page_element_description ' . $params['class'];
@@ -719,7 +715,7 @@ class Draw extends HTMLMeta {
         }
 
         HTML::div( $params );
-        HTML::$echo = $hold;
+        HTML::restore_origonal_echo( $hold );
     }
 
 
@@ -737,8 +733,7 @@ class Draw extends HTMLMeta {
      */
 
     public static function standard_column_right( array $params = [], bool $close_left_column = true ): void {
-        $hold = HTML::$echo;
-        HTML::$echo = true;
+        $hold = self::temporary_change_echo( true );
 
         if ( $close_left_column ) {
             HTML::close_div(); // page_element_description
@@ -786,8 +781,7 @@ class Draw extends HTMLMeta {
             HTML::close_div();
         }
         HTML::close_div();
-
-        HTML::$echo = $hold;
+        HTML::restore_origonal_echo( $hold );
     }
 
 
@@ -803,8 +797,7 @@ class Draw extends HTMLMeta {
      */
 
     public static function standard_single_column( array $params = [] ): void {
-        $hold = HTML::$echo;
-        HTML::$echo = true;
+        $hold = self::temporary_change_echo( true );
 
         if ( isset ( $params['class'] ) ) {
             $params['class'] = 'page_element_main ' . $params['class'];
@@ -813,7 +806,7 @@ class Draw extends HTMLMeta {
         }
 
         HTML::div( $params );
-        HTML::$echo = $hold;
+        HTML::restore_origonal_echo( $hold );
     }
 
 

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -1122,6 +1122,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $params['id'] = 'upl_' . Hash::random_id_string();
         }
 
+        $params['type'] = 'file';
+
         $container_class = 'standard_button__margin upload_button_container';
         if ( isset( $params['hidden'] ) && $params['hidden'] ) {
             $container_class .= ' hidden';
@@ -1140,31 +1142,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         } else {
             $params['class'] = $standard_class;
         }
-
-        $params['type'] = 'file';
-
         $item .= self::html_tag_open( 'input', $params, $skip_fields );
-
-        // $item .= "<input type='file'";
-        // foreach ( $params as $field => $value ) {
-        //     if ( in_array( $field, $skip_fields ) ) {
-        //         continue;
-        //     }
-        //     switch ( $field ) {
-        //         case 'multiple':
-        //             $item .= $value ? ' multiple' : '';
-        //             break;
-        //         case 'checked':
-        //             $item .= $value ? ' checked' : '';
-        //             break;
-        //         case 'disabled':
-        //             $item .= $value ? ' disabled' : '';
-        //             break;
-        //         default:
-        //             $item .= " {$field}='{$value}'";
-        //     }
-        // }
-        // $item .= '>';
         $item .= "<span class='upload_button_padding upload_file_selected_feedback' id='{$params['id']}__text_feedback'>No file selected</span>";
         $item .= "</label>";
 
@@ -1195,11 +1173,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      */
 
     public static function submit( array $params = [] ): string {
-        $element = "<input type='submit'";
-        foreach ( $params as $index => $value ) {
-            $element .= " {$index}='{$value}'";
-        }
-        $element .= '>';
+        $params['type'] = 'submit';
+        $element = self::html_tag_open( 'input', $params );
         self::handle_echo( $element );
         return $element;
     }
@@ -1225,6 +1200,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      *                                          Default: null
      * @param   boolean         $disabled       Whether or not to disable each column
      * 
+     * @throws  InvalidInputException   If $data_left or $data_right is invalid.
+     * 
      * @static
      * @access  public
      * @since   LRS 3.14.3
@@ -1249,7 +1226,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         } else if ( is_string ( $data_left ) ) {
             $values_left = $data_left;
         } else {
-            throw new \Exception( 'Invalid data type for $data_left' );
+            throw new InvalidInputException( 'Invalid data type for $data_left' );
         }
 
         $is_disabled = $disabled ? " disabled='disabled'" : '';
@@ -1300,7 +1277,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         } else if ( is_string ( $data_right ) ) {
             $values_right = $data_right;
         } else {
-            throw new \Exception( 'Invalid data type for $data_right' );
+            throw new InvalidInputException( 'Invalid data type for $data_right' );
         }
 
         HTML::div( ['class' => 'multicolumn_column multicolumn_buttons_vertical_inline'] );

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -5,6 +5,7 @@ namespace LBF\HTML;
 use Exception;
 use Feather\Icons;
 use LBF\Auth\Hash;
+use LBF\Errors\InvalidInputException;
 use LBF\Errors\MissingRequiredInputException;
 use LBF\HTML\JS;
 use LBF\HTML\HTML;
@@ -607,34 +608,9 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $params['data-requires-validation'] = 1;
         }
 
-        self::html_element_container( 'textarea', $params, $skip_fields );
+        $item .= self::html_element_container( 'textarea', $params, $skip_fields );
 
-        // $item .= "<textarea";
-        // foreach ( $params as $field => $value ) {
-        //     if ( in_array( $field, $skip_fields ) ) {
-        //         continue;
-        //     }
-        //     switch ( $field ) {
-        //         case 'autofocus':
-        //             $item .= $value ? ' autofocus' : '';
-        //             break;
-        //         case 'disabled':
-        //             $item .= $value ? ' disabled' : '';
-        //             break;
-        //         case 'readonly':
-        //             $item .= $value ? ' readonly' : '';
-        //             break;
-        //         case 'required':
-        //             $item .= $value ? ' required' : '';
-        //             break;
-        //         default:
-        //             $item .= " {$field}='{$value}'";
-        //     }
-        // }
-
-        // $item .= ">{$params['value']}</textarea>";
-
-        if ( $params['counter'] && $params['id'] != '' ) {
+        if ( $params['counter'] ) {
             $div_id = Hash::random_id_string( 7 );
             $input = 'counter' . Hash::random_id_string( 5 );
             $item .= "<div id='{$div_id}' class='text_area_counter'></div>";
@@ -676,6 +652,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * 
      * @return  string
      * 
+     * @throws  InvalidInputException   If $params position is not either 'before' or 'after'.
+     * 
      * @static
      * @access  public
      * @since   LRS 3.8.0
@@ -684,7 +662,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
     public static function checkbox( array $params = [] ): string {
         if ( !isset( $params['id'] ) ) {
-            throw new \Exception( "Checkbox field ID not set" );
+            $params['id'] = Hash::random_id_string();
         }
 
         $skip_fields = ['label', 'position', 'container'];
@@ -701,7 +679,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $params['position'] = 'after';
         } else {
             if ( !in_array( $params['position'], ['before', 'after'] ) ) {
-                throw new \Exception( "Parameter 'Position' may be either 'before' or 'after', not '{$params['position']}'" );
+                throw new InvalidInputException( "Parameter 'Position' may be either 'before' or 'after', not '{$params['position']}'" );
             }
         }
 
@@ -722,32 +700,36 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $params['class'] = 'standard_checkbox ' . $params['class'];
         }
 
-        $item .= "<input type='checkbox'";
-        foreach ( $params as $field => $value ) {
-            if ( in_array( $field, $skip_fields ) ) {
-                continue;
-            }
-            switch ( $field ) {
-                case 'autofocus':
-                    $item .= $value ? ' autofocus' : '';
-                    break;
-                case 'checked':
-                    $item .= $value ? ' checked' : '';
-                    break;
-                case 'disabled':
-                    $item .= $value ? ' disabled' : '';
-                    break;
-                case 'indeterminate':
-                    $item .= $value ? ' indeterminate' : '';
-                    break;
-                case 'required':
-                    $item .= $value ? ' required' : '';
-                    break;
-                default:
-                    $item .= " {$field}='{$value}'";
-            }
-        }
-        $item .= ">";
+        $params['type'] = 'checkbox';
+
+        $item .= self::html_tag_open( 'input', $params, $skip_fields );
+
+        // $item .= "<input type='checkbox'";
+        // foreach ( $params as $field => $value ) {
+        //     if ( in_array( $field, $skip_fields ) ) {
+        //         continue;
+        //     }
+        //     switch ( $field ) {
+        //         case 'autofocus':
+        //             $item .= $value ? ' autofocus' : '';
+        //             break;
+        //         case 'checked':
+        //             $item .= $value ? ' checked' : '';
+        //             break;
+        //         case 'disabled':
+        //             $item .= $value ? ' disabled' : '';
+        //             break;
+        //         case 'indeterminate':
+        //             $item .= $value ? ' indeterminate' : '';
+        //             break;
+        //         case 'required':
+        //             $item .= $value ? ' required' : '';
+        //             break;
+        //         default:
+        //             $item .= " {$field}='{$value}'";
+        //     }
+        // }
+        // $item .= ">";
         if ( $params['position'] == 'after' ) {
             if ( isset( $params['label'] ) ) {
                 $item .= "<label for='{$params['id']}'> {$params['label']}</label>";

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -1279,6 +1279,10 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
                     break;
                 case 'checked':
                     $item .= $value ? ' checked' : '';
+                    break;
+                case 'disabled':
+                    $item .= $value ? ' disabled' : '';
+                    break;
                 default:
                     $item .= " {$field}='{$value}'";
             }

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -2,9 +2,9 @@
 
 namespace LBF\HTML;
 
-use Exception;
 use Feather\Icons;
 use LBF\Auth\Hash;
+use LBF\Errors\MethodNotFound;
 use LBF\Errors\InvalidInputException;
 use LBF\Errors\MissingRequiredInputException;
 use LBF\HTML\JS;
@@ -62,6 +62,8 @@ class Forms extends HTMLMeta {
      * 
      * @return  string
      * 
+     * @throws  InvalidInputException   If $params['flex'] value is invalid.
+     * 
      * @static
      * @access  private
      * @since   LRS 3.16.0
@@ -71,7 +73,7 @@ class Forms extends HTMLMeta {
         $set_flex = '';
         if ( isset ( $params['flex'] ) ) {
             if ( !is_numeric( $params['flex'] ) ) {
-                throw new \Exception( "The flex parameter must be a number" );
+                throw new InvalidInputException( "The flex parameter must be a number" );
             }
             $set_flex = " style='flex: {$params['flex']};'";
         }
@@ -179,6 +181,8 @@ class Forms extends HTMLMeta {
      * 
      * @return  string
      * 
+     * @throws  InvalidInputException   If `$params['validate']` is not parsed as an array.
+     * 
      * @static
      * @access  private
      * @since   LRS 3.16.0
@@ -196,7 +200,7 @@ class Forms extends HTMLMeta {
 
             if ( isset ( $params['validate'] ) ) {
                 if ( !is_array( $params['validate'] ) ) {
-                    throw new \Exception( "Validations must be parsed as an array" );
+                    throw new InvalidInputException( "Validations must be parsed as an array" );
                 }
                 $validate += $params['validate'];
             }
@@ -385,6 +389,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * 
      * @return  string
      * 
+     * @throws  MethodNotFound If invalid class method called.
+     * 
      * @static
      * @access  public
      * @since   LRS 3.16.0
@@ -399,7 +405,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             'range', 'search', 'tel', 'time', 'url', 'week',
         ];
         if ( !in_array ( $name, $text_types ) ) {
-            throw new \Exception( "Method '{$name}' does not exist." );
+            throw new MethodNotFound( "Method '{$name}' does not exist." );
         }
         $arguments[0]['type'] = $name;
 

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -774,23 +774,6 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
         $item .= self::html_tag_open( 'input', $params, $skip_fields );
 
-        // $item .= "<input type='radio'";
-        // foreach ( $params as $field => $value ) {
-        //     if ( in_array( $field, $skip_fields ) ) {
-        //         continue;
-        //     }
-        //     switch ( $field ) {
-        //         case 'checked':
-        //             $item .= $value ? ' checked' : '';
-        //             break;
-        //         case 'disabled':
-        //             $item .= $value ? ' disabled' : '';
-        //             break;
-        //         default:
-        //             $item .= " {$field}='{$value}'";
-        //     }
-        // }
-        // $item .= ">";
         if ( $params['position'] == 'after' ) {
             if ( isset( $params['label'] ) ) {
                 $item .= "<label for='{$params['id']}'> {$params['label']}</label>";

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -187,8 +187,7 @@ class Forms extends HTMLMeta {
         if ( isset ( $params['validate'] ) || isset ( $params['required'] ) && $params['required'] ) {
             $item .= "<div id='{$params['id']}__validation_feedback' class='std_validation_feedback'></div>";
 
-            $hold = JS::$echo;
-            JS::$echo = false;
+            $hold = JS::temporary_change_echo( false );
 
             $validate = [];
             $nil_value = '';
@@ -213,7 +212,7 @@ import Input_Validation from './vendor/projector22/lourie-basic-framework/src/js
 const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__validation_feedback', '{$nil_value}');
 {$validator}.general_validator({$validate});"
             );
-            JS::$echo = $hold;
+            JS::restore_origonal_echo( $hold );
         }
         return $item;
     }
@@ -424,13 +423,9 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         }
         $arguments[0]['type'] = $name;
 
-        // $hold = self::$echo;
-        // self::$echo = false;
         $hold = self::temporary_change_echo( false );
         $form = self::text( $arguments[0] );
         self::restore_origonal_echo( $hold );
-        echo "cheese"; die;
-        // self::$echo = $hold;
         
         
         self::handle_echo( $form );
@@ -678,8 +673,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $div_id = Hash::random_id_string( 7 );
             $input = 'counter' . Hash::random_id_string( 5 );
             $item .= "<div id='{$div_id}' class='text_area_counter'></div>";
-            $js_echo_hold = JS::$echo;
-            JS::$echo = false;
+            $hold = JS::temporary_change_echo( false );
             $item .= JS::script_module( "
                 import { text_area_text_counter } from './vendor/projector22/lourie-basic-framework/src/js/forms.js';
                 const $input = document.getElementById('{$params['id']}');
@@ -687,7 +681,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
                     text_area_text_counter('{$params['id']}', '{$div_id}')
                 });"
             );
-            JS::$echo = $js_echo_hold;
+            JS::restore_origonal_echo( $hold );
         }
 
         /**
@@ -1033,10 +1027,9 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         unset( $params['data'] );
         $params['list'] = $data_id;
         $params['autocomplete'] = 'off';
-        $echo_hold = self::$echo;
-        self::$echo = false;
+        $hold = self::temporary_change_echo( false );
         $item .= self::text( $params );
-        self::$echo = $echo_hold;
+        self::restore_origonal_echo( $hold );
         self::handle_echo( $item );
         return $item;
     }
@@ -1200,8 +1193,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      */
 
     public static function content_drawer_arrow( string $element_id, string $show_hide_id ): string {
-        $hold = HTML::$echo;
-        HTML::$echo = false;
+        $hold = HTML::temporary_change_echo( false );
         $svg = new SVG( SVGImages::content_draw_arrow->image() );
         $svg->set_size( 16, 16 )->set_viewbox( 0, 0, 16, 16 );
         /**
@@ -1220,7 +1212,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         document.getElementById('$element_id').onclick = function () {
             show_hide('$show_hide_id');
         };" );
-        HTML::$echo = $hold;
+        HTML::restore_origonal_echo( $hold );
         self::handle_echo( $element );
         return $element;
     }
@@ -1365,8 +1357,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         ?string $title2 = null,
         bool $disabled = false,
     ): void {
-        $hold = self::$echo;
-        self::$echo = true;
+        $hold = self::temporary_change_echo( true );
         HTML::div( [
             'class' => 'multi_class_selector_container',
             'id'    => $id,
@@ -1446,7 +1437,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         " );
 
         HTML::close_div(); // multi_class_selector_container $id
-        self::$echo = $hold;
+        self::restore_origonal_echo( $hold );
     }
 
 
@@ -1468,9 +1459,9 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
     public static function submit_load_page( string $button_text, string $page, ?string $tab = null ): string {
         $button = "<form method='get'>";
-        $hold = self::$echo;
+        $hold = self::temporary_change_echo( false );
         $button .= self::submit( ['value' => $button_text, 'class' => 'std_button'] );
-        self::$echo = $hold;
+        self::restore_origonal_echo( $hold );
         $button .= page( $page, false, true );
         if ( !is_null ( $tab ) ) {
             $button .= tab( $tab, true );

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -805,6 +805,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * 
      * @return  string
      * 
+     * @throws  InvalidInputException   If $params checked is not parsed as a bool.
+     * 
      * @static
      * @access  public
      * @since   LRS 3.7.6
@@ -814,13 +816,13 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
     public static function toggle( array $params = [] ): string {
         if ( !isset( $params['id'] ) ) {
-            throw new \Exception( "Text field ID not set" );
+            $params['id'] = Hash::random_id_string();
         }
         if ( !isset ( $params['checked'] ) ) {
             $params['checked'] = false;
         }
         if ( $params['checked'] != true && $params['checked'] != false ) {
-            throw new \Exception( "Invalid value for param 'checked' set. It must be either true or false" );
+            throw new InvalidInputException( "Invalid value for param 'checked' set. It must be either true or false" );
         }
 
         $skip_fields = ['label', 'hint', 'container', 'off', 'on'];
@@ -848,35 +850,40 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
          * Off
          */
 
-        if ( isset ( $params['on'] ) || isset( $params['off']) ) {
+        if ( isset ( $params['on'] ) || isset( $params['off'] ) ) {
             $item .= "<div class='selector_contain'>";
             if ( isset( $params['off'] ) ) {
                 $item .= "<span class='selector_text'>{$params['off']}</span>";
             }
         }
 
+        $params['type'] = 'checkbox';
+
         /**
          * The toggle, wrapped in a label so the whole thing is clickable.
          */
         $item .= "<label class='selector_switch'>";
-        $item .= "<input type='checkbox'";
-        foreach ( $params as $field => $value ) {
-            if ( in_array( $field, $skip_fields ) ) {
-                continue;
-            }
-            switch ( $field ) {
-                case 'disabled':
-                    $item .= $value ? ' disabled' : '';
-                    break;
-                case 'checked':
-                    $item .= $value ? ' checked' : '';
-                    break;
-                default;
-                    $item .= " {$field}='{$value}'";
-            }
-        }
 
-        $item .= "><span class='slider round'></span>";
+        $item .= self::html_tag_open( 'input', $params, $skip_fields );
+
+        // $item .= "<input type='checkbox'";
+        // foreach ( $params as $field => $value ) {
+        //     if ( in_array( $field, $skip_fields ) ) {
+        //         continue;
+        //     }
+        //     switch ( $field ) {
+        //         case 'disabled':
+        //             $item .= $value ? ' disabled' : '';
+        //             break;
+        //         case 'checked':
+        //             $item .= $value ? ' checked' : '';
+        //             break;
+        //         default;
+        //             $item .= " {$field}='{$value}'";
+        //     }
+        // }
+
+        $item .= "<span class='slider round'></span>";
         $item .= "</label>";
 
         /**

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -487,33 +487,6 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
         $item .= self::html_element_container( 'select', $params, $skip_fields );
 
-        // $item .= "<select";
-        // foreach ( $params as $field => $value ) {
-        //     if ( in_array( $field, $skip_fields ) ) {
-        //         continue;
-        //     }
-        //     switch ( $field ) {
-        //         case 'autofocus':
-        //             $item .= $value ? ' autofocus' : '';
-        //             break;
-        //         case 'disabled':
-        //             $item .= $value ? ' disabled' : '';
-        //             break;
-        //         case 'multiple':
-        //             $item .= $value ? ' multiple' : '';
-        //             break;
-        //         case 'required':
-        //             $item .= $value ? ' required' : '';
-        //             break;
-        //         default:
-        //             $item .= " {$field}='{$value}'";
-        //     }
-        // }
-
-
-
-        // $item .= ">{$params['data']}</select>";
-
         /**
          * Hint
          */
@@ -552,11 +525,11 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
     public static function textarea( array $params = [] ): string {
         if ( !isset ( $params['id'] ) ) {
-            throw new \Exception( "Select box field ID not set" );
+            $params['id'] = Hash::random_id_string();
         }
 
         $skip_fields = [
-            'label', 'hint', 'validate', 'flex', 'value', 'counter', 'resize',
+            'hint', 'validate', 'flex', 'value', 'counter', 'resize',
             'container', 'hidden',
         ];
         $item = '';
@@ -629,33 +602,37 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         } else {
             $params['class'] = $standard_class;
         }
-        $item .= "<textarea";
-        foreach ( $params as $field => $value ) {
-            if ( in_array( $field, $skip_fields ) ) {
-                continue;
-            }
-            switch ( $field ) {
-                case 'autofocus':
-                    $item .= $value ? ' autofocus' : '';
-                    break;
-                case 'disabled':
-                    $item .= $value ? ' disabled' : '';
-                    break;
-                case 'readonly':
-                    $item .= $value ? ' readonly' : '';
-                    break;
-                case 'required':
-                    $item .= $value ? ' required' : '';
-                    break;
-                default:
-                    $item .= " {$field}='{$value}'";
-            }
-        }
+
         if ( isset ( $params['validate'] ) || isset( $params['required'] ) && $params['required'] ) {
-            $item .= " data-requires-validation=1";
+            $params['data-requires-validation'] = 1;
         }
 
-        $item .= ">{$params['value']}</textarea>";
+        self::html_element_container( 'textarea', $params, $skip_fields );
+
+        // $item .= "<textarea";
+        // foreach ( $params as $field => $value ) {
+        //     if ( in_array( $field, $skip_fields ) ) {
+        //         continue;
+        //     }
+        //     switch ( $field ) {
+        //         case 'autofocus':
+        //             $item .= $value ? ' autofocus' : '';
+        //             break;
+        //         case 'disabled':
+        //             $item .= $value ? ' disabled' : '';
+        //             break;
+        //         case 'readonly':
+        //             $item .= $value ? ' readonly' : '';
+        //             break;
+        //         case 'required':
+        //             $item .= $value ? ' required' : '';
+        //             break;
+        //         default:
+        //             $item .= " {$field}='{$value}'";
+        //     }
+        // }
+
+        // $item .= ">{$params['value']}</textarea>";
 
         if ( $params['counter'] && $params['id'] != '' ) {
             $div_id = Hash::random_id_string( 7 );

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -950,7 +950,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
     public static function filter( array $params = [] ): string {
         if ( !isset( $params['id'] ) ) {
-            throw new \Exception( "Text field ID not set" );
+            $params['id'] = Hash::random_id_string();
         }
         $skip_fields = ['label', 'hint', 'validate', 'flex', 'container'];
         $item = '';
@@ -997,37 +997,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         } else {
             $params['class'] = $standard_class;
         }
-
-        
         $item .= self::html_tag_open( 'input', $params, $skip_fields );
-
-
-        // $item .= "<input";
-        // foreach ( $params as $field => $value ) {
-        //     if ( in_array( $field, $skip_fields ) ) {
-        //         continue;
-        //     }
-        //     switch ( $field ) {
-        //         case 'autofocus':
-        //             $item .= $value ? ' autofocus' : '';
-        //             break;
-        //         case 'disabled':
-        //             $item .= $value ? ' disabled' : '';
-        //             break;
-        //         case 'readonly':
-        //             $item .= $value ? ' readonly' : '';
-        //             break;
-        //         case 'required':
-        //             $item .= $value ? ' required' : '';
-        //             break;
-        //         default:
-        //             $item .= " {$field}='{$value}'";
-        //     }
-        // }
-        // $item .= ">";
-
-
-
         $icon = new Icons;
         $item .= $icon->get( 'search', echo: false );
         $item .= "</span>";
@@ -1050,9 +1020,13 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
     /**
      * Draw out an <input type='hidden'> element
      * 
-     * @param   array   $params     The fields to be added to the hidden input, either id or name must be set.
+     * @param   array   $params     The fields to be added to the hidden input, 
+     *                              either id or name must be set.
      * 
      * @return  string
+     * 
+     * @throws  MissingRequiredInputException   If neither id nor name is set as a param.
+     * @throws  MissingRequiredInputException   If no value is set.
      * 
      * @static
      * @access  public
@@ -1061,21 +1035,15 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @since   LRS 3.16.1  Merged param $value into $params.
      */
 
-    public static function hidden_input( array $params = [] ): string {
+    public static function hidden_input( array $params ): string {
         if ( !isset( $params['id'] ) && !isset( $params['name'] ) ) {
-            throw new \Exception( "Identifier not set. There must be either an 'id' or a 'name' parameter set" );
+            throw new MissingRequiredInputException( "Identifier not set. There must be either an 'id' or a 'name' parameter set" );
         }
         if ( !isset( $params['value'] ) ) {
-            throw new \Exception( "Hidden value not set. \$params['value'] must be set." );
+            throw new MissingRequiredInputException( "Hidden value not set. \$params['value'] must be set." );
         }
-
-        $item = "<input type='hidden'";
-
-        foreach ( $params as $field => $value ) {
-            $item .= " {$field}='{$value}'";
-        }
-
-        $item .= ">";
+        $params['type'] = 'hidden';
+        $item = self::html_tag_open( 'input', $params );
 
         self::handle_echo( $item );
         return $item;

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -424,10 +424,15 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         }
         $arguments[0]['type'] = $name;
 
-        $hold = self::$echo;
-        self::$echo = false;
+        // $hold = self::$echo;
+        // self::$echo = false;
+        $hold = self::temporary_change_echo( false );
         $form = self::text( $arguments[0] );
-        self::$echo = $hold;
+        self::restore_origonal_echo( $hold );
+        echo "cheese"; die;
+        // self::$echo = $hold;
+        
+        
         self::handle_echo( $form );
         return $form;
     }

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -1140,26 +1140,31 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         } else {
             $params['class'] = $standard_class;
         }
-        $item .= "<input type='file'";
-        foreach ( $params as $field => $value ) {
-            if ( in_array( $field, $skip_fields ) ) {
-                continue;
-            }
-            switch ( $field ) {
-                case 'multiple':
-                    $item .= $value ? ' multiple' : '';
-                    break;
-                case 'checked':
-                    $item .= $value ? ' checked' : '';
-                    break;
-                case 'disabled':
-                    $item .= $value ? ' disabled' : '';
-                    break;
-                default:
-                    $item .= " {$field}='{$value}'";
-            }
-        }
-        $item .= '>';
+
+        $params['type'] = 'file';
+
+        $item .= self::html_tag_open( 'input', $params, $skip_fields );
+
+        // $item .= "<input type='file'";
+        // foreach ( $params as $field => $value ) {
+        //     if ( in_array( $field, $skip_fields ) ) {
+        //         continue;
+        //     }
+        //     switch ( $field ) {
+        //         case 'multiple':
+        //             $item .= $value ? ' multiple' : '';
+        //             break;
+        //         case 'checked':
+        //             $item .= $value ? ' checked' : '';
+        //             break;
+        //         case 'disabled':
+        //             $item .= $value ? ' disabled' : '';
+        //             break;
+        //         default:
+        //             $item .= " {$field}='{$value}'";
+        //     }
+        // }
+        // $item .= '>';
         $item .= "<span class='upload_button_padding upload_file_selected_feedback' id='{$params['id']}__text_feedback'>No file selected</span>";
         $item .= "</label>";
 

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -341,39 +341,41 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $standard_class .= ' st_input_width_default';
         }
 
+        if ( isset ( $params['validate'] ) || isset( $params['required'] ) && $params['required'] ) {
+            $params['data-requires-validation'] = 1;
+        }
+
         if ( isset ( $params['class'] ) ) {
             $params['class'] = $standard_class . ' ' . $params['class'];
         } else {
             $params['class'] = $standard_class;
         }
-        $item .= "<input";
-        foreach ( $params as $field => $value ) {
-            if ( in_array( $field, $skip_fields ) ) {
-                continue;
-            }
-            switch ( $field ) {
-                case 'autofocus':
-                    $item .= $value ? ' autofocus' : '';
-                    break;
-                case 'disabled':
-                    $item .= $value ? ' disabled' : '';
-                    break;
-                case 'readonly':
-                    $item .= $value ? ' readonly' : '';
-                    break;
-                case 'required':
-                    $item .= $value ? ' required' : '';
-                    break;
-                default:
-                    $item .= " {$field}='{$value}'";
-            }
-        }
 
-        if ( isset ( $params['validate'] ) || isset( $params['required'] ) && $params['required'] ) {
-            $item .= " data-requires-validation=1";
-        }
+        $item .= self::html_tag_open( 'input', $params, $skip_fields );
+        // $item .= "<input";
+        // foreach ( $params as $field => $value ) {
+        //     if ( in_array( $field, $skip_fields ) ) {
+        //         continue;
+        //     }
+        //     switch ( $field ) {
+        //         case 'autofocus':
+        //             $item .= $value ? ' autofocus' : '';
+        //             break;
+        //         case 'disabled':
+        //             $item .= $value ? ' disabled' : '';
+        //             break;
+        //         case 'readonly':
+        //             $item .= $value ? ' readonly' : '';
+        //             break;
+        //         case 'required':
+        //             $item .= $value ? ' required' : '';
+        //             break;
+        //         default:
+        //             $item .= " {$field}='{$value}'";
+        //     }
+        // }
 
-        $item .= ">";
+        // $item .= ">";
 
         /**
          * Hint

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -998,29 +998,36 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $params['class'] = $standard_class;
         }
 
-        $item .= "<input";
-        foreach ( $params as $field => $value ) {
-            if ( in_array( $field, $skip_fields ) ) {
-                continue;
-            }
-            switch ( $field ) {
-                case 'autofocus':
-                    $item .= $value ? ' autofocus' : '';
-                    break;
-                case 'disabled':
-                    $item .= $value ? ' disabled' : '';
-                    break;
-                case 'readonly':
-                    $item .= $value ? ' readonly' : '';
-                    break;
-                case 'required':
-                    $item .= $value ? ' required' : '';
-                    break;
-                default:
-                    $item .= " {$field}='{$value}'";
-            }
-        }
-        $item .= ">";
+        
+        $item .= self::html_tag_open( 'input', $params, $skip_fields );
+
+
+        // $item .= "<input";
+        // foreach ( $params as $field => $value ) {
+        //     if ( in_array( $field, $skip_fields ) ) {
+        //         continue;
+        //     }
+        //     switch ( $field ) {
+        //         case 'autofocus':
+        //             $item .= $value ? ' autofocus' : '';
+        //             break;
+        //         case 'disabled':
+        //             $item .= $value ? ' disabled' : '';
+        //             break;
+        //         case 'readonly':
+        //             $item .= $value ? ' readonly' : '';
+        //             break;
+        //         case 'required':
+        //             $item .= $value ? ' required' : '';
+        //             break;
+        //         default:
+        //             $item .= " {$field}='{$value}'";
+        //     }
+        // }
+        // $item .= ">";
+
+
+
         $icon = new Icons;
         $item .= $icon->get( 'search', echo: false );
         $item .= "</span>";

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -5,6 +5,7 @@ namespace LBF\HTML;
 use Exception;
 use Feather\Icons;
 use LBF\Auth\Hash;
+use LBF\Errors\MissingRequiredInputException;
 use LBF\HTML\JS;
 use LBF\HTML\HTML;
 use LBF\HTML\HTMLMeta;
@@ -277,7 +278,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
     public static function text( array $params = [] ): string {
         if ( !isset( $params['id'] ) ) {
-            throw new \Exception( "Text field ID not set" );
+            $params['id'] = Hash::random_id_string();
         }
         $skip_fields = ['label', 'hint', 'validate', 'flex', 'container', 'hidden'];
         $item = '';
@@ -352,30 +353,6 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         }
 
         $item .= self::html_tag_open( 'input', $params, $skip_fields );
-        // $item .= "<input";
-        // foreach ( $params as $field => $value ) {
-        //     if ( in_array( $field, $skip_fields ) ) {
-        //         continue;
-        //     }
-        //     switch ( $field ) {
-        //         case 'autofocus':
-        //             $item .= $value ? ' autofocus' : '';
-        //             break;
-        //         case 'disabled':
-        //             $item .= $value ? ' disabled' : '';
-        //             break;
-        //         case 'readonly':
-        //             $item .= $value ? ' readonly' : '';
-        //             break;
-        //         case 'required':
-        //             $item .= $value ? ' required' : '';
-        //             break;
-        //         default:
-        //             $item .= " {$field}='{$value}'";
-        //     }
-        // }
-
-        // $item .= ">";
 
         /**
          * Hint
@@ -443,6 +420,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * 
      * @return  string
      * 
+     * @throws  MissingRequiredInputException   If field 'data' is missing.
+     * 
      * @static
      * @access  public
      * @since   LRS 3.8.0
@@ -453,10 +432,10 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
     public static function select_box( array $params = [] ): string {
         if ( !isset ( $params['id'] ) ) {
-            throw new \Exception( "Select box field ID not set" );
+            $params['id'] = Hash::random_id_string();
         }
         if ( !isset ( $params['data'] ) ) {
-            throw new \Exception( "Select box field data not set" );
+            throw new MissingRequiredInputException( "Select box field data not set" );
         }
 
         $skip_fields = [
@@ -496,37 +475,44 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         } else {
             $params['class'] = $standard_class;
         }
-        $item .= "<select";
-        foreach ( $params as $field => $value ) {
-            if ( in_array( $field, $skip_fields ) ) {
-                continue;
-            }
-            switch ( $field ) {
-                case 'autofocus':
-                    $item .= $value ? ' autofocus' : '';
-                    break;
-                case 'disabled':
-                    $item .= $value ? ' disabled' : '';
-                    break;
-                case 'multiple':
-                    $item .= $value ? ' multiple' : '';
-                    break;
-                case 'required':
-                    $item .= $value ? ' required' : '';
-                    break;
-                default:
-                    $item .= " {$field}='{$value}'";
-            }
-        }
+
         if ( isset ( $params['validate'] ) || isset( $params['required'] ) && $params['required'] ) {
-            $item .= " data-requires-validation=1";
+            $params['data-requires-validation'] =1;
             if ( isset( $params['validate']['nil_value'] ) ) {
                 if ( !str_contains( $params['data'], "value='{$params['validate']['nil_value']}'" ) ) {
-                    $item .= " data-validated=1";
+                    $params['data-validated'] = 1;
                 }
             }
         }
-        $item .= ">{$params['data']}</select>";
+
+        $item .= self::html_element_container( 'select', $params, $skip_fields );
+
+        // $item .= "<select";
+        // foreach ( $params as $field => $value ) {
+        //     if ( in_array( $field, $skip_fields ) ) {
+        //         continue;
+        //     }
+        //     switch ( $field ) {
+        //         case 'autofocus':
+        //             $item .= $value ? ' autofocus' : '';
+        //             break;
+        //         case 'disabled':
+        //             $item .= $value ? ' disabled' : '';
+        //             break;
+        //         case 'multiple':
+        //             $item .= $value ? ' multiple' : '';
+        //             break;
+        //         case 'required':
+        //             $item .= $value ? ' required' : '';
+        //             break;
+        //         default:
+        //             $item .= " {$field}='{$value}'";
+        //     }
+        // }
+
+
+
+        // $item .= ">{$params['data']}</select>";
 
         /**
          * Hint

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -863,26 +863,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
          * The toggle, wrapped in a label so the whole thing is clickable.
          */
         $item .= "<label class='selector_switch'>";
-
         $item .= self::html_tag_open( 'input', $params, $skip_fields );
-
-        // $item .= "<input type='checkbox'";
-        // foreach ( $params as $field => $value ) {
-        //     if ( in_array( $field, $skip_fields ) ) {
-        //         continue;
-        //     }
-        //     switch ( $field ) {
-        //         case 'disabled':
-        //             $item .= $value ? ' disabled' : '';
-        //             break;
-        //         case 'checked':
-        //             $item .= $value ? ' checked' : '';
-        //             break;
-        //         default;
-        //             $item .= " {$field}='{$value}'";
-        //     }
-        // }
-
         $item .= "<span class='slider round'></span>";
         $item .= "</label>";
 
@@ -925,6 +906,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * 
      * @return  string
      * 
+     * @throws  MissingRequiredInputException   If $params['data'] not set.
+     * 
      * @static
      * @access  public
      * @since   LRS 3.8.0
@@ -934,7 +917,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
     public static function combo_box( array $params = [] ): string {
         if ( !isset( $params['data'] ) ) {
-            throw new Exception( "\$params['data'] has not been set. This parameter must be set for a combo box." );
+            throw new MissingRequiredInputException( "\$params['data'] has not been set. This parameter must be set for a combo box." );
         }
         $data_id = Hash::random_id_string( 7 );
         $item = "<datalist id='{$data_id}'>{$params['data']}</datalist>";
@@ -1037,8 +1020,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
                     $item .= " {$field}='{$value}'";
             }
         }
-        $icon = new Icons;
         $item .= ">";
+        $icon = new Icons;
         $item .= $icon->get( 'search', echo: false );
         $item .= "</span>";
 

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -704,32 +704,6 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
         $item .= self::html_tag_open( 'input', $params, $skip_fields );
 
-        // $item .= "<input type='checkbox'";
-        // foreach ( $params as $field => $value ) {
-        //     if ( in_array( $field, $skip_fields ) ) {
-        //         continue;
-        //     }
-        //     switch ( $field ) {
-        //         case 'autofocus':
-        //             $item .= $value ? ' autofocus' : '';
-        //             break;
-        //         case 'checked':
-        //             $item .= $value ? ' checked' : '';
-        //             break;
-        //         case 'disabled':
-        //             $item .= $value ? ' disabled' : '';
-        //             break;
-        //         case 'indeterminate':
-        //             $item .= $value ? ' indeterminate' : '';
-        //             break;
-        //         case 'required':
-        //             $item .= $value ? ' required' : '';
-        //             break;
-        //         default:
-        //             $item .= " {$field}='{$value}'";
-        //     }
-        // }
-        // $item .= ">";
         if ( $params['position'] == 'after' ) {
             if ( isset( $params['label'] ) ) {
                 $item .= "<label for='{$params['id']}'> {$params['label']}</label>";
@@ -753,6 +727,9 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * 
      * @return  string
      * 
+     * @throws  MissingRequiredInputException   If $params['name'] is missing.
+     * @throws  InvalidInputException           If $params position is not either 'before' or 'after'.
+     * 
      * @static
      * @access  public
      * @since   LRS 3.16.1
@@ -760,15 +737,11 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
     public static function radio( array $params = [] ): string {
         if ( !isset( $params['name'] ) ) {
-            throw new Exception( "Missing \$param attribute 'name'. Radio buttons require the 'name' attribute to be set." );
+            throw new MissingRequiredInputException( "Missing \$param attribute 'name'. Radio buttons require the 'name' attribute to be set." );
         }
 
         if ( !isset( $params['id'] ) ) {
             $params['id'] = Hash::random_id_string( 7 );
-        }
-
-        if ( isset ( $param['label'] ) && !isset ( $param['id'] ) ) {
-            throw new Exception( "Missing \$param attribute 'id'. A label require the 'id' attribute to be set." );
         }
 
         $skip_fields = ['label', 'position'];
@@ -778,9 +751,11 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $params['position'] = 'after';
         } else {
             if ( !in_array( $params['position'], ['before', 'after'] ) ) {
-                throw new \Exception( "Parameter 'Position' may be either 'before' or 'after', not '{$params['position']}'" );
+                throw new InvalidInputException( "Parameter 'Position' may be either 'before' or 'after', not '{$params['position']}'" );
             }
         }
+
+        $params['type'] = 'radio';
 
         // Container
         $item .= self::checkbox_input_container( $params );
@@ -797,23 +772,25 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $params['class'] = 'standard_radiobox ' . $params['class'];
         }
 
-        $item .= "<input type='radio'";
-        foreach ( $params as $field => $value ) {
-            if ( in_array( $field, $skip_fields ) ) {
-                continue;
-            }
-            switch ( $field ) {
-                case 'checked':
-                    $item .= $value ? ' checked' : '';
-                    break;
-                case 'disabled':
-                    $item .= $value ? ' disabled' : '';
-                    break;
-                default:
-                    $item .= " {$field}='{$value}'";
-            }
-        }
-        $item .= ">";
+        $item .= self::html_tag_open( 'input', $params, $skip_fields );
+
+        // $item .= "<input type='radio'";
+        // foreach ( $params as $field => $value ) {
+        //     if ( in_array( $field, $skip_fields ) ) {
+        //         continue;
+        //     }
+        //     switch ( $field ) {
+        //         case 'checked':
+        //             $item .= $value ? ' checked' : '';
+        //             break;
+        //         case 'disabled':
+        //             $item .= $value ? ' disabled' : '';
+        //             break;
+        //         default:
+        //             $item .= " {$field}='{$value}'";
+        //     }
+        // }
+        // $item .= ">";
         if ( $params['position'] == 'after' ) {
             if ( isset( $params['label'] ) ) {
                 $item .= "<label for='{$params['id']}'> {$params['label']}</label>";

--- a/src/HTML/Forms.php
+++ b/src/HTML/Forms.php
@@ -7,6 +7,7 @@ use Feather\Icons;
 use LBF\Auth\Hash;
 use LBF\HTML\JS;
 use LBF\HTML\HTML;
+use LBF\HTML\HTMLMeta;
 use LBF\Img\SVGImages;
 use SVGTools\SVG;
 
@@ -20,24 +21,13 @@ use SVGTools\SVG;
  * @author  Gareth Palmer  [Github & Gitlab /projector22]
  * 
  * @since   LRS 3.6.0
- * @since   LRS 3.11.0  Moved to `Framework\HTML` namespace from `PageElements`
- * @since   LRS 3.28.0  Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
- *                  Namespace changed from `Framework` to `LBF`.
+ * @since   LRS 3.11.0      Moved to `Framework\HTML` namespace from `PageElements`
+ * @since   LRS 3.28.0      Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
+ *                          Namespace changed from `Framework` to `LBF`.
+ * @since   LBF 0.1.6-beta  Added extension `HTMLMeta`.
  */
 
-class Forms {
-
-    /**
-     * Whether or not to echo the element. If false the element will be returned instead
-     * 
-     * @var boolean $echo  Default: true
-     * 
-     * @access  public
-     * @since   LRS 3.6.0
-     */
-
-    public static bool $echo = true;
-
+class Forms extends HTMLMeta {
 
     /**
      * Draw and add the a label onto an html element
@@ -46,6 +36,7 @@ class Forms {
      * 
      * @return  string
      * 
+     * @static
      * @access  private
      * @since   LRS 3.12.8
      * @since   LRS 3.16.0 Added a built in 'required' element.
@@ -69,6 +60,7 @@ class Forms {
      * 
      * @return  string
      * 
+     * @static
      * @access  private
      * @since   LRS 3.16.0
      */
@@ -98,6 +90,7 @@ class Forms {
      * 
      * @return  string
      * 
+     * @static
      * @access  private
      * @since   LRS 3.16.0
      */
@@ -121,6 +114,7 @@ class Forms {
      * 
      * @return  string
      * 
+     * @static
      * @access  private
      * @since   LRS 3.16.0
      */
@@ -141,6 +135,7 @@ class Forms {
      * 
      * @return  string
      * 
+     * @static
      * @access  private
      * @since   LRS 3.16.1
      */
@@ -161,6 +156,7 @@ class Forms {
      * 
      * @return  string
      * 
+     * @static
      * @access  private
      * @since   LRS 3.16.0
      */
@@ -181,6 +177,7 @@ class Forms {
      * 
      * @return  string
      * 
+     * @static
      * @access  private
      * @since   LRS 3.16.0
      */
@@ -192,10 +189,10 @@ class Forms {
 
             $hold = JS::$echo;
             JS::$echo = false;
-    
+
             $validate = [];
             $nil_value = '';
-            
+
             if ( isset ( $params['validate'] ) ) {
                 if ( !is_array( $params['validate'] ) ) {
                     throw new \Exception( "Validations must be parsed as an array" );
@@ -235,7 +232,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
     const REQUIRED_STAR = " <span class='required_star'>*</span>";
 
     /**
-     * Draw the text `(Required)` next to a field label to indicate the field 
+     * Draw the text `(Required)` next to a field label to indicate the field
      * is required.
      * 
      * @var string  REQUIRED_TEXT
@@ -255,6 +252,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * 
      * @var string  $required_default   Default: `Form::REQUIRED_TEXT`
      * 
+     * @static
      * @access  public
      * @since   LRS 3.16.0
      */
@@ -270,14 +268,15 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @param   array   $params     The params to parse into the text field.
      *                              Default: `[]`
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.12.8
      * @since   LRS 3.16.0 Revamped with new styling, labels, hints and validation.
      */
 
-    public static function text( array $params = [] ) {
+    public static function text( array $params = [] ): string {
         if ( !isset( $params['id'] ) ) {
             throw new \Exception( "Text field ID not set" );
         }
@@ -383,7 +382,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
         $item .= self::element_hint( $params );
 
-        
+
         /**
          * Validation
          */
@@ -394,25 +393,25 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $item .= "</div>"; // Container
         }
 
-        if ( self::$echo ) {
-            echo $item;
-        } else {
-            return $item;
-        }
+        self::handle_echo( $item );
+        return $item;
     }
 
 
     /**
      * Call the name of a text field elements
      * 
-     * @param   string  $name   The name of the method called
-     * @param   array   $arguments
+     * @param   string  $name       The name of the method called
+     * @param   array   $arguments  The parsed arguments.
      * 
+     * @return  string
+     * 
+     * @static
      * @access  public
      * @since   LRS 3.16.0
      */
 
-    public static function __callStatic( $name, $arguments ) {
+    public static function __callStatic( string $name, array $arguments ) {
         if ( $name == 'colour' ) {
             $name = 'color';
         }
@@ -424,7 +423,13 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             throw new \Exception( "Method '{$name}' does not exist." );
         }
         $arguments[0]['type'] = $name;
-        self::text( $arguments[0] );
+
+        $hold = self::$echo;
+        self::$echo = false;
+        $form = self::text( $arguments[0] );
+        self::$echo = $hold;
+        self::handle_echo( $form );
+        return $form;
     }
 
 
@@ -434,8 +439,9 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @param   string  $params         The parameters to add to the select box.
      *                                  Default: `[]`
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.8.0
      * @since   LRS 3.13.0  Rewritten and revamped
@@ -443,7 +449,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @since   LRS 3.16.0  Revamped with new styling, labels, hints and validation. Removed params $data, $is_multiple
      */
 
-    public static function select_box( array $params = [] ) {
+    public static function select_box( array $params = [] ): string {
         if ( !isset ( $params['id'] ) ) {
             throw new \Exception( "Select box field ID not set" );
         }
@@ -536,11 +542,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $item .= "</div>"; // Container
         }
 
-        if ( self::$echo ) {
-            echo $item;
-        } else {
-            return $item;
-        }
+        self::handle_echo( $item );
+        return $item;
     }
 
 
@@ -550,19 +553,20 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @param   string  $params         The parameters to be attached to the text area
      *                                  Default: `[]`
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.8.0
      * @since   LRS 3.13.0  Revamped and replaced all params
      * @since   LRS 3.16.0  Revamped with new styling, labels, hints and validation. Removed param  $draw_counter
      */
 
-    public static function textarea( array $params = [] ) {
+    public static function textarea( array $params = [] ): string {
         if ( !isset ( $params['id'] ) ) {
             throw new \Exception( "Select box field ID not set" );
         }
-        
+
         $skip_fields = [
             'label', 'hint', 'validate', 'flex', 'value', 'counter', 'resize',
             'container', 'hidden',
@@ -623,7 +627,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
                     $standard_class .= ' resize_none';
             }
         }
-        
+
         if ( !isset ( $params['value'] ) ) {
             $params['value'] = '';
         }
@@ -631,7 +635,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         if ( !isset( $params['counter'] ) ) {
             $params['counter'] = true;
         }
-        
+
         if ( isset ( $params['class'] ) ) {
             $params['class'] = $standard_class . ' ' . $params['class'];
         } else {
@@ -695,11 +699,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
         $item .= "</div>"; // Container
 
-        if ( self::$echo ) {
-            echo $item;
-        } else {
-            return $item;
-        }
+        self::handle_echo( $item );
+        return $item;
     }
 
 
@@ -709,14 +710,15 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @param   string  $params     The fields to be added to the checkbox input.
      *                              Default: []
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.8.0
      * @since   LRS 3.16.0  Revamped
      */
 
-    public static function checkbox( array $params = [] ) {
+    public static function checkbox( array $params = [] ): string {
         if ( !isset( $params['id'] ) ) {
             throw new \Exception( "Checkbox field ID not set" );
         }
@@ -792,11 +794,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $item .= "</div>";
         }
 
-        if ( self::$echo ) {
-            echo $item;
-        } else {
-            return $item;
-        }
+        self::handle_echo( $item );
+        return $item;
     }
 
 
@@ -806,13 +805,14 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @param   string  $params     The fields to be added to the radio input.
      *                              Default: []
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.16.1
      */
 
-    public static function radio( array $params = [] ) {
+    public static function radio( array $params = [] ): string {
         if ( !isset( $params['name'] ) ) {
             throw new Exception( "Missing \$param attribute 'name'. Radio buttons require the 'name' attribute to be set." );
         }
@@ -876,11 +876,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
         $item .= "</div>";
 
-        if ( self::$echo ) {
-            echo $item;
-        } else {
-            return $item;
-        }
+        self::handle_echo( $item );
+        return $item;
     }
 
 
@@ -900,15 +897,16 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @param   array   $params         The properties to add to the toggle.
      *                                  Default: []
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.7.6
      * @since   LRS 3.13.0    Updated and split the labels into it's own method
      * @since   LRS 3.16.1  Revamped and removed params $id & $checked.
      */
 
-    public static function toggle( array $params = [] ) {
+    public static function toggle( array $params = [] ): string {
         if ( !isset( $params['id'] ) ) {
             throw new \Exception( "Text field ID not set" );
         }
@@ -996,11 +994,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $item .= "</div>"; // Container
         }
 
-        if ( self::$echo ) {
-            echo $item;
-        } else {
-            return $item;
-        }
+        self::handle_echo( $item );
+        return $item;
     }
 
 
@@ -1015,15 +1010,16 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @param   string  $params         The parameters to add to the combo box, list and autocomplete will be overwritten if set.
      *                                  Default: []
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.8.0
      * @since   LRS 3.13.0    Completely revamped
      * @since   LRS 3.16.1  Merged param $data into $params.
      */
 
-    public static function combo_box( array $params = [] ) {
+    public static function combo_box( array $params = [] ): string {
         if ( !isset( $params['data'] ) ) {
             throw new Exception( "\$params['data'] has not been set. This parameter must be set for a combo box." );
         }
@@ -1036,11 +1032,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         self::$echo = false;
         $item .= self::text( $params );
         self::$echo = $echo_hold;
-        if ( self::$echo ) {
-            echo $item;
-        } else {
-            return $item;
-        }
+        self::handle_echo( $item );
+        return $item;
     }
 
 
@@ -1050,8 +1043,9 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @param   array   $params     Parameters to attach to the filter.
      *                              Default: []
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      * @since   LRS 3.11.1  Removed params, $id, $placeholder, $value; added param $params
@@ -1059,7 +1053,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @since   LRS 3.16.0  Revamped with new styling, labels, hints and validation. Renamed to search_filter from filter_box
      */
 
-    public static function filter( array $params = [] ) {
+    public static function filter( array $params = [] ): string {
         if ( !isset( $params['id'] ) ) {
             throw new \Exception( "Text field ID not set" );
         }
@@ -1146,11 +1140,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             $item .= "</div>"; // Container
         }
 
-        if ( self::$echo ) {
-            echo $item;
-        } else {
-            return $item;
-        }
+        self::handle_echo( $item );
+        return $item;
     }
 
 
@@ -1159,15 +1150,16 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * 
      * @param   array   $params     The fields to be added to the hidden input, either id or name must be set.
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.8.0
      * @since   LRS 3.13.0  Rewritten and replaced the params
      * @since   LRS 3.16.1  Merged param $value into $params.
      */
 
-    public static function hidden_input( array $params = [] ) {
+    public static function hidden_input( array $params = [] ): string {
         if ( !isset( $params['id'] ) && !isset( $params['name'] ) ) {
             throw new \Exception( "Identifier not set. There must be either an 'id' or a 'name' parameter set" );
         }
@@ -1183,11 +1175,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
         $item .= ">";
 
-        if ( self::$echo ) {
-            echo $item;
-        } else {
-            return $item;
-        }
+        self::handle_echo( $item );
+        return $item;
     }
 
 
@@ -1197,14 +1186,15 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @param   string  $element_id     The id of the the span which contains the arrow
      * @param   string  $show_hide_id   The id of the element you wish to show or hide
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.9.1
      * @since   LRS 3.13.0    Renamed $id to $show_hide_id and added $element_id
      */
 
-    public static function content_drawer_arrow( string $element_id, string $show_hide_id ) {
+    public static function content_drawer_arrow( string $element_id, string $show_hide_id ): string {
         $hold = HTML::$echo;
         HTML::$echo = false;
         $svg = new SVG( SVGImages::content_draw_arrow->image() );
@@ -1226,11 +1216,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
             show_hide('$show_hide_id');
         };" );
         HTML::$echo = $hold;
-        if ( self::$echo ) {
-            echo $element;
-        } else {
-            return $element;
-        }
+        self::handle_echo( $element );
+        return $element;
     }
 
 
@@ -1246,14 +1233,15 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * 
      * @param   array   $params     All the elements to include on the input element
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.12.7
      * @since   LRS 3.16.1  Completely revamped, to use non default decorations and new standards.
      */
 
-    public static function upload_file( array $params = [] ) {
+    public static function upload_file( array $params = [] ): string {
         $skip_fields = ['label', 'hint', 'content', 'hidden'];
         $item = self::label( $params );
 
@@ -1311,11 +1299,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
 
         JS::script_module( "import UploaderElement from './vendor/projector22/lourie-basic-framework/src/js/uploader_element.js';\nconst upload = new UploaderElement('{$params['id']}');" );
 
-        if ( self::$echo ) {
-            echo $item;
-        } else {
-            return $item;
-        }
+        self::handle_echo( $item );
+        return $item;
     }
 
 
@@ -1324,23 +1309,21 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * 
      * @param   array   $params     All the elements to include on the input element
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access  public
      * @since   LRS 3.12.8
      */
 
-    public static function submit( array $params = [] ) {
+    public static function submit( array $params = [] ): string {
         $element = "<input type='submit'";
         foreach ( $params as $index => $value ) {
             $element .= " {$index}='{$value}'";
         }
         $element .= '>';
-        if ( self::$echo ) {
-            echo $element;
-        } else {
-            return $element;
-        }
+        self::handle_echo( $element );
+        return $element;
     }
 
 
@@ -1364,6 +1347,7 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      *                                          Default: null
      * @param   boolean         $disabled       Whether or not to disable each column
      * 
+     * @static
      * @access  public
      * @since   LRS 3.14.3
      */
@@ -1455,14 +1439,14 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         import {handle_column_changes} from './vendor/projector22/lourie-basic-framework/src/js/forms.js';
         handle_column_changes('{$id}');
         " );
- 
+
         HTML::close_div(); // multi_class_selector_container $id
         self::$echo = $hold;
     }
 
 
     /**
-     * A simple form with a submit button to load a page based on the button click as 
+     * A simple form with a submit button to load a page based on the button click as
      * a means of navigation.
      * 
      * @param   string  $button_text    The text of the button.
@@ -1470,13 +1454,14 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
      * @param   string  $tab            The &t= tab to load.
      *                                  Default: null
      * 
-     * @return  string|void
+     * @return  string
      * 
+     * @static
      * @access public
      * @since   LRS 3.15.4
      */
 
-    public static function submit_load_page( string $button_text, string $page, ?string $tab = null ) {
+    public static function submit_load_page( string $button_text, string $page, ?string $tab = null ): string {
         $button = "<form method='get'>";
         $hold = self::$echo;
         $button .= self::submit( ['value' => $button_text, 'class' => 'std_button'] );
@@ -1487,11 +1472,8 @@ const {$validator} = new Input_Validation('{$params['id']}','{$params['id']}__va
         }
         $button .= "</form>";
 
-        if ( self::$echo ) {
-            echo $button;
-        } else {
-            return $button;
-        }   
+        self::handle_echo( $button );
+        return $button;
     }
 
 }

--- a/src/HTML/HTMLElements.php
+++ b/src/HTML/HTMLElements.php
@@ -379,7 +379,7 @@ class HTMLElements extends HTMLMeta {
         $item = '<a';
 
         foreach ( $params as $key => $value ) {
-            if ( !in_array( $key, $skip_params ) ) {
+            if ( in_array( $key, $skip_params ) ) {
                 continue;
             }
             switch( $key ) {

--- a/src/HTML/HTMLElements.php
+++ b/src/HTML/HTMLElements.php
@@ -393,7 +393,7 @@ class HTMLElements extends HTMLMeta {
 
         $item .= ">{$params['text']}</a>";
 
-        self::handle_echo( $item, $skip_params );
+        self::handle_echo( $item, $params );
         return $item;
     }
 

--- a/src/HTML/HTMLElements.php
+++ b/src/HTML/HTMLElements.php
@@ -376,22 +376,24 @@ class HTMLElements extends HTMLMeta {
             'echo', 'text',
         ];
 
-        $item = '<a';
+        $item = self::html_element_container( 'a', $params, $skip_params );
 
-        foreach ( $params as $key => $value ) {
-            if ( in_array( $key, $skip_params ) ) {
-                continue;
-            }
-            switch( $key ) {
-                case 'new_tab':
-                    $item .= $value ? ( ' ' . Draw::NEW_TAB ) : '';
-                    break;
-                default:
-                    $item .= " {$key}='{$value}'";
-            }
-        }
+        // $item = '<a';
 
-        $item .= ">{$params['text']}</a>";
+        // foreach ( $params as $key => $value ) {
+        //     if ( in_array( $key, $skip_params ) ) {
+        //         continue;
+        //     }
+        //     switch( $key ) {
+        //         case 'new_tab':
+        //             $item .= $value ? ( ' ' . Draw::NEW_TAB ) : '';
+        //             break;
+        //         default:
+        //             $item .= " {$key}='{$value}'";
+        //     }
+        // }
+
+        // $item .= ">{$params['text']}</a>";
 
         self::handle_echo( $item, $params );
         return $item;

--- a/src/HTML/HTMLElements.php
+++ b/src/HTML/HTMLElements.php
@@ -381,6 +381,8 @@ class HTMLElements extends HTMLMeta {
      * 
      * @return  string
      * 
+     * @throws  MissingRequiredInputException   If param `src` is missing.
+     * 
      * @static
      * @access  public
      * @since   LRS 3.17.1
@@ -388,10 +390,10 @@ class HTMLElements extends HTMLMeta {
 
     public static function img( array $params = [] ): string {
         if ( !isset( $params['src'] ) ) {
-            throw new Exception( "Path to file not set. Please set param 'src" );
+            throw new MissingRequiredInputException( "Path to file not set. Please set param 'src" );
         }
 
-        $skip_params = ['unit'];
+        // $skip_params = ['unit'];
 
         $unit = $params['unit'] ?? 'px';
         $dimensions = ['height', 'width'];
@@ -402,17 +404,19 @@ class HTMLElements extends HTMLMeta {
                 }
             }
         }
+
+        $item = self::html_tag_open( 'img', $params, ['unit'] );
         
-        $item = '<img';
+        // $item = '<img';
 
-        foreach ( $params as $index => $value ) {
-            if ( in_array( $index, $skip_params ) ) {
-                continue;
-            }
-            $item .= " {$index}='{$value}'";
-        }
+        // foreach ( $params as $index => $value ) {
+        //     if ( in_array( $index, $skip_params ) ) {
+        //         continue;
+        //     }
+        //     $item .= " {$index}='{$value}'";
+        // }
 
-        $item .= '>';
+        // $item .= '>';
 
         self::handle_echo( $item );
         return $item;
@@ -447,10 +451,6 @@ class HTMLElements extends HTMLMeta {
      */
 
     public static function iframe( array $params ): string {
-        // $skip_params = [
-        //     'default_unit',
-        // ];
-
         if ( !isset( $params['src'] ) && !isset( $params['srcdoc'] ) ) {
             throw new MissingRequiredInputException( "An iframe must have either the parameter 'src' or 'srcdoc'." );
         }
@@ -485,18 +485,6 @@ class HTMLElements extends HTMLMeta {
         $params['text'] = 'Sorry, your browser does not allow iframe previews.';
 
         $item = self::html_element_container( 'iframe', $params, ['default_unit'] );
-
-        // $item = '<iframe';
-
-        // foreach ( $params as $key => $value ) {
-        //     if ( in_array( $key, $skip_params ) ) {
-        //         continue;
-        //     }
-        //     $item .= " {$key}='{$value}'";
-        // }
-
-        // $item .= '>Sorry, your browser does not allow previews.';
-        // $item .= '</iframe>';
 
         self::handle_echo( $item );
         return $item;

--- a/src/HTML/HTMLElements.php
+++ b/src/HTML/HTMLElements.php
@@ -393,8 +393,6 @@ class HTMLElements extends HTMLMeta {
             throw new MissingRequiredInputException( "Path to file not set. Please set param 'src" );
         }
 
-        // $skip_params = ['unit'];
-
         $unit = $params['unit'] ?? 'px';
         $dimensions = ['height', 'width'];
         foreach ( $dimensions as $dimension ) {
@@ -406,17 +404,6 @@ class HTMLElements extends HTMLMeta {
         }
 
         $item = self::html_tag_open( 'img', $params, ['unit'] );
-        
-        // $item = '<img';
-
-        // foreach ( $params as $index => $value ) {
-        //     if ( in_array( $index, $skip_params ) ) {
-        //         continue;
-        //     }
-        //     $item .= " {$index}='{$value}'";
-        // }
-
-        // $item .= '>';
 
         self::handle_echo( $item );
         return $item;

--- a/src/HTML/HTMLElements.php
+++ b/src/HTML/HTMLElements.php
@@ -17,8 +17,9 @@ use LBF\HTML\HTMLMeta;
  * @author  Gareth Palmer  [Github & Gitlab /projector22]
  * 
  * @since   LRS 3.12.5
- * @since   LRS 3.28.0  Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
- *                      Namespace changed from `Framework` to `LBF`.
+ * @since   LRS 3.28.0      Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
+ *                          Namespace changed from `Framework` to `LBF`.
+ * @since   LBF 0.1.5-beta  Added extension `HTMLMeta`.
  */
 
 class HTMLElements extends HTMLMeta {
@@ -87,10 +88,9 @@ class HTMLElements extends HTMLMeta {
      */
 
     public static function div_container( array $params = [], string $content = '' ): string {
-        $echo_hold = self::$echo;
-        self::$echo = false;
+        $hold = self::temporary_change_echo( false );
         $element = self::div( $params ) . $content . self::close_div();
-        self::$echo = $echo_hold;
+        self::restore_origonal_echo( $hold );
         self::handle_echo( $element );
         return $element;
     }
@@ -160,10 +160,9 @@ class HTMLElements extends HTMLMeta {
      */
 
     public static function span_container( array $params = [], string $content = '' ): string {
-        $echo_hold = self::$echo;
-        self::$echo = false;
+        $hold = self::temporary_change_echo( false );
         $element = self::span( $params ) . $content . self::close_span();
-        self::$echo = $echo_hold;
+        self::restore_origonal_echo( $hold );
         self::handle_echo( $element );
         return $element;
     }
@@ -233,10 +232,9 @@ class HTMLElements extends HTMLMeta {
      */
 
     public static function p_container( array $params = [], string $content = '' ): string {
-        $echo_hold = self::$echo;
-        self::$echo = false;
+        $hold = self::temporary_change_echo( false );
         $element = self::p( $params ) . $content . self::close_p();
-        self::$echo = $echo_hold;
+        self::restore_origonal_echo( $hold );
         self::handle_echo( $element );
         return $element;
     }

--- a/src/HTML/HTMLElements.php
+++ b/src/HTML/HTMLElements.php
@@ -324,6 +324,8 @@ class HTMLElements extends HTMLMeta {
      * @static
      * @access  public
      * @since   LRS 3.12.8
+     * 
+     * @deprecated  LBF 0.1.6-beta
      */
 
     public static function link( string $href, ?string $text, array $params = [] ): string {
@@ -340,6 +342,59 @@ class HTMLElements extends HTMLMeta {
         $element .= ">{$text}</a>";
         self::handle_echo( $element );
         return $element;
+    }
+
+
+    /**
+     * Rebuild of `link`.
+     * 
+     * @param   array   $params The elements to add to the link
+     * 
+     * @return  string
+     * 
+     * @throws  MissingRequiredInputException   If $params['text'] missing.
+     * 
+     * @static
+     * @access  public
+     * @since   LBF 0.1.6-beta
+     */
+
+    public static function a( array $params ): string {
+        if ( !isset( $params['href'] ) ) {
+            $params['href'] = 'javascript:void(0)';
+        }
+
+        if ( !isset( $params['text'] ) ) {
+            throw new MissingRequiredInputException( "Param 'text' required" );
+        }
+
+        if ( !isset( $params['id'] ) ) {
+            $params['id'] = Hash::random_id_string();
+        }
+
+        $skip_params = [
+            'echo', 'text',
+        ];
+
+        $item = '<a';
+
+        foreach ( $params as $key => $value ) {
+            if ( !in_array( $key, $skip_params ) ) {
+                continue;
+            }
+            switch( $key ) {
+                case 'new_tab':
+                    $item .= $value ? ( ' ' . Draw::NEW_TAB ) : '';
+                    break;
+                default:
+                    $item .= " {$key}='{$value}'";
+            }
+        }
+
+        $item .= ">{$params['text']}</a>";
+
+        self::handle_echo( $item, $skip_params );
+        return $item;
     }
 
 

--- a/src/HTML/HTMLElements.php
+++ b/src/HTML/HTMLElements.php
@@ -438,6 +438,8 @@ class HTMLElements extends HTMLMeta {
      * 
      * @return  string
      * 
+     * @throws  MissingRequiredInputException   If params src & srcdoc are missing.
+     * 
      * @static
      * @access  public
      * @since   LRS 3.11.1
@@ -445,12 +447,12 @@ class HTMLElements extends HTMLMeta {
      */
 
     public static function iframe( array $params ): string {
-        $skip_params = [
-            'default_unit',
-        ];
+        // $skip_params = [
+        //     'default_unit',
+        // ];
 
         if ( !isset( $params['src'] ) && !isset( $params['srcdoc'] ) ) {
-            throw new Exception( "An iframe must have either the parameter 'src' or 'srcdoc'." );
+            throw new MissingRequiredInputException( "An iframe must have either the parameter 'src' or 'srcdoc'." );
         }
 
         if ( !isset( $params['id'] ) ) {
@@ -480,17 +482,21 @@ class HTMLElements extends HTMLMeta {
             }
         }
 
-        $item = '<iframe';
+        $params['text'] = 'Sorry, your browser does not allow iframe previews.';
 
-        foreach ( $params as $key => $value ) {
-            if ( in_array( $key, $skip_params ) ) {
-                continue;
-            }
-            $item .= " {$key}='{$value}'";
-        }
+        $item = self::html_element_container( 'iframe', $params. ['default_unit'] );
 
-        $item .= '>Sorry, your browser does not allow previews.';
-        $item .= '</iframe>';
+        // $item = '<iframe';
+
+        // foreach ( $params as $key => $value ) {
+        //     if ( in_array( $key, $skip_params ) ) {
+        //         continue;
+        //     }
+        //     $item .= " {$key}='{$value}'";
+        // }
+
+        // $item .= '>Sorry, your browser does not allow previews.';
+        // $item .= '</iframe>';
 
         self::handle_echo( $item );
         return $item;

--- a/src/HTML/HTMLElements.php
+++ b/src/HTML/HTMLElements.php
@@ -2,7 +2,6 @@
 
 namespace LBF\HTML;
 
-use Exception;
 use LBF\Auth\Hash;
 use LBF\Errors\InvalidInputException;
 use LBF\Errors\MissingRequiredInputException;

--- a/src/HTML/HTMLElements.php
+++ b/src/HTML/HTMLElements.php
@@ -484,7 +484,7 @@ class HTMLElements extends HTMLMeta {
 
         $params['text'] = 'Sorry, your browser does not allow iframe previews.';
 
-        $item = self::html_element_container( 'iframe', $params. ['default_unit'] );
+        $item = self::html_element_container( 'iframe', $params, ['default_unit'] );
 
         // $item = '<iframe';
 

--- a/src/HTML/HTMLElements.php
+++ b/src/HTML/HTMLElements.php
@@ -257,13 +257,6 @@ class HTMLElements extends HTMLMeta {
     public static function heading( int $size, string $content, array $params = [] ): string {
         $params['text'] = $content;
         $element = self::html_element_container( "h{$size}", $params );
-
-
-        // $element = "<h{$size}";
-        // foreach ( $params as $index => $value ) {
-        //     $element .= " {$index}='$value'";
-        // }
-        // $element .= ">{$content}</h{$size}>";
         self::handle_echo( $element );
         return $element;
     }
@@ -284,14 +277,8 @@ class HTMLElements extends HTMLMeta {
      */    
 
     public static function form( array $params = [], bool $new_tab = false ): string {
-        $element = '<form';
-        foreach ( $params as $item => $value ) {
-            $element .= " {$item}='{$value}'";
-        }
-        if ( $new_tab ) {
-            $element .= ' ' . Draw::NEW_TAB;
-        }
-        $element .= '>';
+        $params['new_tab'] = $new_tab;
+        $element = self::html_tag_open( 'form', $params );
         self::handle_echo( $element );
         return $element;
     }

--- a/src/HTML/HTMLElements.php
+++ b/src/HTML/HTMLElements.php
@@ -255,11 +255,15 @@ class HTMLElements extends HTMLMeta {
      */
 
     public static function heading( int $size, string $content, array $params = [] ): string {
-        $element = "<h{$size}";
-        foreach ( $params as $index => $value ) {
-            $element .= " {$index}='$value'";
-        }
-        $element .= ">{$content}</h{$size}>";
+        $params['text'] = $content;
+        $element = self::html_element_container( "h{$size}", $params );
+
+
+        // $element = "<h{$size}";
+        // foreach ( $params as $index => $value ) {
+        //     $element .= " {$index}='$value'";
+        // }
+        // $element .= ">{$content}</h{$size}>";
         self::handle_echo( $element );
         return $element;
     }
@@ -377,23 +381,6 @@ class HTMLElements extends HTMLMeta {
         ];
 
         $item = self::html_element_container( 'a', $params, $skip_params );
-
-        // $item = '<a';
-
-        // foreach ( $params as $key => $value ) {
-        //     if ( in_array( $key, $skip_params ) ) {
-        //         continue;
-        //     }
-        //     switch( $key ) {
-        //         case 'new_tab':
-        //             $item .= $value ? ( ' ' . Draw::NEW_TAB ) : '';
-        //             break;
-        //         default:
-        //             $item .= " {$key}='{$value}'";
-        //     }
-        // }
-
-        // $item .= ">{$params['text']}</a>";
 
         self::handle_echo( $item, $params );
         return $item;

--- a/src/HTML/HTMLMeta.php
+++ b/src/HTML/HTMLMeta.php
@@ -2,6 +2,8 @@
 
 namespace LBF\HTML;
 
+use LBF\Auth\Hash;
+
 /**
  * This class contains meta classes & properties for the LBF\HTML namespace.
  * 
@@ -21,15 +23,27 @@ class HTMLMeta {
      * 
      * @static
      * @access  public
-     * @since   LRS 3.12.5
-     * @since   LBF 0.1.5   Moved to HTMLMeta
+     * @since   LRS 3.6.0
+     * @since   LBF 0.1.5-beta  Moved to HTMLMeta
      */
 
     public static bool $echo = true;
 
+    /**
+     * Contains the temporary values of $echo as required.
+     * 
+     * @var array   $temporary_echo     Default: []
+     * 
+     * @static
+     * @since   LBF 0.1.6-beta
+     */
+
+    public static array $temporary_echo = [];
+
 
     /**
-     * Handle the echoing of elements as desired.
+     * Handle the echoing of elements as desired. If `$param['echo'] is
+     * parsed, it will overwrite self::$echo.
      * 
      * @param   string  $element    The element to echo.
      * 
@@ -38,18 +52,62 @@ class HTMLMeta {
      * @since   0.1.5-beta
      */
 
-    protected static function handle_echo( string $element ): void {
-        if ( self::$echo ) {
+    protected static function handle_echo( string $element, array $params = []  ): void {
+        if ( isset( $params['echo'] ) ) {
+            if ( $params['echo'] ) {
+                echo $element;
+            }
+        } else if ( self::$echo ) {
             echo $element;
         }
     }
 
 
     /**
+     * Perform a temporary change to the $echo value.
+     * 
+     * Paired with `restore_origonal_echo` method.
+     * 
+     * @param   bool    $temp_echo  The echo value to change to.
+     * 
+     * @return  string  The id of the change, used in restoring the origonal value.
+     * 
+     * @static
+     * @access  protected
+     * @since   0.1.6-beta
+     */
+
+    protected static function temporary_change_echo( bool $temp_echo ): string {
+        $id = Hash::random_id_string();
+        self::$temporary_echo[$id] = self::$echo;
+        self::$echo = $temp_echo;
+        return $id;
+    }
+
+
+    /**
+     * Restore the origonal echo value, as identified by $id.
+     * 
+     * Paired with `temporary_change_echo` method.
+     * 
+     * @param   string  $id The id of the echo to restore to.
+     * 
+     * @static
+     * @access  protected
+     * @since   0.1.6-beta
+     */
+    protected static function restore_origonal_echo( string $id ): void {
+        self::$echo = self::$temporary_echo[$id];
+        unset( self::$temporary_echo[$id] );
+    }
+
+
+    /**
      * Create an opening tag, as defined by the param `$tag`.
      * 
-     * @param   string  $tag    The tag to create.
-     * @param   array   $params Any params to add to the tag
+     * @param   string  $tag                The tag to create.
+     * @param   array   $params             Any params to add to the tag.
+     * @param   array   $skip_params_extra  Any extra skip params besides the already defined list to apply to the tag.
      * 
      * @return  string
      * 
@@ -58,16 +116,20 @@ class HTMLMeta {
      * @since   0.1.5-beta
      */
 
-    protected static function html_tag_open( string $tag, array $params ): string {
-        $skip_params = [
+    protected static function html_tag_open( string $tag, array $params, array $skip_params_extra = [] ): string {
+        $skip_params = array_merge( [
             'maxmin',
-        ];
+            'echo',
+        ], $skip_params_extra );
         $element = "<{$tag}";
         foreach ( $params as $key => $value ) {
             if ( in_array( $key, $skip_params ) ) {
                 continue;
             }
-            $element .= " {$key}='{$value}'";
+            switch ( $key ) {
+                default:
+                    $element .= " {$key}='{$value}'";
+            }
         }
         $element .= '>';
         return $element;

--- a/src/HTML/HTMLMeta.php
+++ b/src/HTML/HTMLMeta.php
@@ -122,8 +122,9 @@ class HTMLMeta {
             'text',
             'content',
             'echo',
+            'data',
         ], $skip_params_extra );
-        $inner_text = $params['text'] ?? $params['content'] ?? '';
+        $inner_text = $params['text'] ?? $params['content'] ?? $params['data'] ?? '';
         $element = "<{$tag}";
         $element .= self::assign_key_values( $params, $skip_params );
         $element .= ">{$inner_text}</{$tag}>";
@@ -191,6 +192,9 @@ class HTMLMeta {
                     break;
                 case 'required':
                     $element .= $value ? ' required' : '';
+                    break;
+                case 'multiple':
+                    $element .= $value ? ' multiple' : '';
                     break;
                 default:
                     $element .= " {$key}='{$value}'";

--- a/src/HTML/HTMLMeta.php
+++ b/src/HTML/HTMLMeta.php
@@ -196,7 +196,7 @@ class HTMLMeta {
             }
             switch ( $key ) {
                 case 'new_tab':
-                    if ( !isset( $params['href'] ) ) {
+                    if ( !isset( $params['link'] ) ) {
                         $element .= $value ? " target='_blank' rel='noopener'" : '';
                     }
                     break;
@@ -221,7 +221,7 @@ class HTMLMeta {
                 case 'indeterminate':
                     $element .= $value ? ' indeterminate' : '';
                     break;
-                case 'href':
+                case 'link':
                     if ( isset( $params['new_tab'] ) && $params['new_tab'] ) {
                         $element .= " onClick='javascript:window.open(\"{$value}\", \"_blank\")'";
                     } else {

--- a/src/HTML/HTMLMeta.php
+++ b/src/HTML/HTMLMeta.php
@@ -73,11 +73,11 @@ class HTMLMeta {
      * @return  string  The id of the change, used in restoring the origonal value.
      * 
      * @static
-     * @access  protected
+     * @access  public
      * @since   0.1.6-beta
      */
 
-    protected static function temporary_change_echo( bool $temp_echo ): string {
+    public static function temporary_change_echo( bool $temp_echo ): string {
         $id = Hash::random_id_string();
         self::$temporary_echo[$id] = self::$echo;
         self::$echo = $temp_echo;
@@ -93,10 +93,10 @@ class HTMLMeta {
      * @param   string  $id The id of the echo to restore to.
      * 
      * @static
-     * @access  protected
+     * @access  public
      * @since   0.1.6-beta
      */
-    protected static function restore_origonal_echo( string $id ): void {
+    public static function restore_origonal_echo( string $id ): void {
         self::$echo = self::$temporary_echo[$id];
         unset( self::$temporary_echo[$id] );
     }

--- a/src/HTML/HTMLMeta.php
+++ b/src/HTML/HTMLMeta.php
@@ -123,7 +123,14 @@ class HTMLMeta {
             'content',
             'echo',
             'data',
+            'label',
         ], $skip_params_extra );
+        if ( $tag == 'textarea' ) {
+            if ( isset( $params['value'] ) ) {
+                $params['text'] = $params['value'];
+                unset( $params['value'] );
+            }
+        }
         $inner_text = $params['text'] ?? $params['content'] ?? $params['data'] ?? '';
         $element = "<{$tag}";
         $element .= self::assign_key_values( $params, $skip_params );

--- a/src/HTML/HTMLMeta.php
+++ b/src/HTML/HTMLMeta.php
@@ -103,6 +103,46 @@ class HTMLMeta {
 
 
     /**
+     * Create a complete tag container.
+     * 
+     * @param   string  $tag                The tag to create.
+     * @param   array   $params             Any params to add to the tag.
+     * @param   array   $skip_params_extra  Any extra skip params besides the already defined list to apply to the tag.
+     * 
+     * @return  string
+     * 
+     * @static
+     * @access  protected
+     * @since   0.1.6-beta
+     */
+
+    protected static function html_element_container( string $tag, array $params, array $skip_params_extra ): string {
+        $skip_params = array_merge( [
+            'maxmin',
+            'text',
+            'content',
+            'echo',
+        ], $skip_params_extra );
+        $element = "<{$tag}";
+        $inner_text = $params['text'] ?? $params['content'] ?? '';
+        foreach ( $params as $key => $value ) {
+            if ( in_array( $key, $skip_params ) ) {
+                continue;
+            }
+            switch ( $key ) {
+                case 'new_tab':
+                    $element .= $value ? " target='_blank' rel='noopener'" : '';
+                    break;
+                default:
+                    $element .= " {$key}='{$value}'";
+            }
+        }
+        $element .= ">{$inner_text}</{$tag}>";
+        return $element;
+    }
+
+
+    /**
      * Create an opening tag, as defined by the param `$tag`.
      * 
      * @param   string  $tag                The tag to create.
@@ -127,6 +167,9 @@ class HTMLMeta {
                 continue;
             }
             switch ( $key ) {
+                case 'new_tab':
+                    $element .= $value ? " target='_blank' rel='noopener'" : '';
+                    break;
                 default:
                     $element .= " {$key}='{$value}'";
             }

--- a/src/HTML/HTMLMeta.php
+++ b/src/HTML/HTMLMeta.php
@@ -123,20 +123,9 @@ class HTMLMeta {
             'content',
             'echo',
         ], $skip_params_extra );
-        $element = "<{$tag}";
         $inner_text = $params['text'] ?? $params['content'] ?? '';
-        foreach ( $params as $key => $value ) {
-            if ( in_array( $key, $skip_params ) ) {
-                continue;
-            }
-            switch ( $key ) {
-                case 'new_tab':
-                    $element .= $value ? " target='_blank' rel='noopener'" : '';
-                    break;
-                default:
-                    $element .= " {$key}='{$value}'";
-            }
-        }
+        $element = "<{$tag}";
+        $element .= self::assign_key_values( $params, $skip_params );
         $element .= ">{$inner_text}</{$tag}>";
         return $element;
     }
@@ -162,6 +151,27 @@ class HTMLMeta {
             'echo',
         ], $skip_params_extra );
         $element = "<{$tag}";
+        $element .= self::assign_key_values( $params, $skip_params );
+        $element .= '>';
+        return $element;
+    }
+
+
+    /**
+     * Assign the key value pairs to the element.
+     * 
+     * @param   array   $params         Any params to add to the tag.
+     * @param   array   $skip_params    All the params to skip.
+     * 
+     * @return  string
+     * 
+     * @static
+     * @access  private
+     * @since   0.1.6-beta
+     */
+
+    private static function assign_key_values( array $params, array $skip_params ): string {
+        $element = '';
         foreach ( $params as $key => $value ) {
             if ( in_array( $key, $skip_params ) ) {
                 continue;
@@ -170,11 +180,22 @@ class HTMLMeta {
                 case 'new_tab':
                     $element .= $value ? " target='_blank' rel='noopener'" : '';
                     break;
+                case 'autofocus':
+                    $element .= $value ? ' autofocus' : '';
+                    break;
+                case 'disabled':
+                    $element .= $value ? ' disabled' : '';
+                    break;
+                case 'readonly':
+                    $element .= $value ? ' readonly' : '';
+                    break;
+                case 'required':
+                    $element .= $value ? ' required' : '';
+                    break;
                 default:
                     $element .= " {$key}='{$value}'";
             }
         }
-        $element .= '>';
         return $element;
     }
 

--- a/src/HTML/HTMLMeta.php
+++ b/src/HTML/HTMLMeta.php
@@ -196,7 +196,9 @@ class HTMLMeta {
             }
             switch ( $key ) {
                 case 'new_tab':
-                    $element .= $value ? " target='_blank' rel='noopener'" : '';
+                    if ( !isset( $params['href'] ) ) {
+                        $element .= $value ? " target='_blank' rel='noopener'" : '';
+                    }
                     break;
                 case 'autofocus':
                     $element .= $value ? ' autofocus' : '';
@@ -218,6 +220,13 @@ class HTMLMeta {
                     break;
                 case 'indeterminate':
                     $element .= $value ? ' indeterminate' : '';
+                    break;
+                case 'href':
+                    if ( isset( $params['new_tab'] ) && $params['new_tab'] ) {
+                        $element .= " onClick='javascript:window.open(\"{$value}\", \"_blank\")'";
+                    } else {
+                        $element .= " onClick='window.location.href = \"{$value}\"'";
+                    }
                     break;
                 default:
                     $element .= " {$key}='{$value}'";

--- a/src/HTML/HTMLMeta.php
+++ b/src/HTML/HTMLMeta.php
@@ -119,9 +119,9 @@ class HTMLMeta {
     protected static function html_element_container( string $tag, array $params, array $skip_params_extra = [] ): string {
         $skip_params = array_merge( [
             'maxmin',
+            'echo',
             'text',
             'content',
-            'echo',
             'data',
             'label',
         ], $skip_params_extra );
@@ -157,6 +157,10 @@ class HTMLMeta {
         $skip_params = array_merge( [
             'maxmin',
             'echo',
+            'text',
+            'content',
+            'data',
+            'label',
         ], $skip_params_extra );
         $element = "<{$tag}";
         $element .= self::assign_key_values( $params, $skip_params );
@@ -202,6 +206,12 @@ class HTMLMeta {
                     break;
                 case 'multiple':
                     $element .= $value ? ' multiple' : '';
+                    break;
+                case 'checked':
+                    $element .= $value ? ' checked' : '';
+                    break;
+                case 'indeterminate':
+                    $element .= $value ? ' indeterminate' : '';
                     break;
                 default:
                     $element .= " {$key}='{$value}'";

--- a/src/HTML/HTMLMeta.php
+++ b/src/HTML/HTMLMeta.php
@@ -116,7 +116,7 @@ class HTMLMeta {
      * @since   0.1.6-beta
      */
 
-    protected static function html_element_container( string $tag, array $params, array $skip_params_extra ): string {
+    protected static function html_element_container( string $tag, array $params, array $skip_params_extra = [] ): string {
         $skip_params = array_merge( [
             'maxmin',
             'text',

--- a/src/HTML/HTMLMeta.php
+++ b/src/HTML/HTMLMeta.php
@@ -49,7 +49,7 @@ class HTMLMeta {
      * 
      * @static
      * @access  protected
-     * @since   0.1.5-beta
+     * @since   LBF 0.1.5-beta
      */
 
     protected static function handle_echo( string $element, array $params = []  ): void {
@@ -74,7 +74,7 @@ class HTMLMeta {
      * 
      * @static
      * @access  public
-     * @since   0.1.6-beta
+     * @since   LBF 0.1.6-beta
      */
 
     public static function temporary_change_echo( bool $temp_echo ): string {
@@ -94,12 +94,32 @@ class HTMLMeta {
      * 
      * @static
      * @access  public
-     * @since   0.1.6-beta
+     * @since   LBF 0.1.6-beta
      */
     public static function restore_origonal_echo( string $id ): void {
         self::$echo = self::$temporary_echo[$id];
         unset( self::$temporary_echo[$id] );
     }
+
+
+    /**
+     * The default skip params used by this class.
+     * 
+     * @var array   $default_skip_params
+     * 
+     * @static
+     * @access  private
+     * @since   LBF 0.1.6-beta
+     */
+
+    private static array $default_skip_params = [
+        'maxmin',
+        'echo',
+        'text',
+        'content',
+        'data',
+        'label',
+    ];
 
 
     /**
@@ -113,18 +133,11 @@ class HTMLMeta {
      * 
      * @static
      * @access  protected
-     * @since   0.1.6-beta
+     * @since   LBF 0.1.6-beta
      */
 
     protected static function html_element_container( string $tag, array $params, array $skip_params_extra = [] ): string {
-        $skip_params = array_merge( [
-            'maxmin',
-            'echo',
-            'text',
-            'content',
-            'data',
-            'label',
-        ], $skip_params_extra );
+        $skip_params = array_merge( self::$default_skip_params, $skip_params_extra );
         if ( $tag == 'textarea' ) {
             if ( isset( $params['value'] ) ) {
                 $params['text'] = $params['value'];
@@ -150,18 +163,11 @@ class HTMLMeta {
      * 
      * @static
      * @access  protected
-     * @since   0.1.5-beta
+     * @since   LBF 0.1.5-beta
      */
 
     protected static function html_tag_open( string $tag, array $params, array $skip_params_extra = [] ): string {
-        $skip_params = array_merge( [
-            'maxmin',
-            'echo',
-            'text',
-            'content',
-            'data',
-            'label',
-        ], $skip_params_extra );
+        $skip_params = array_merge( self::$default_skip_params, $skip_params_extra );
         $element = "<{$tag}";
         $element .= self::assign_key_values( $params, $skip_params );
         $element .= '>';
@@ -179,7 +185,7 @@ class HTMLMeta {
      * 
      * @static
      * @access  private
-     * @since   0.1.6-beta
+     * @since   LBF 0.1.6-beta
      */
 
     private static function assign_key_values( array $params, array $skip_params ): string {
@@ -233,7 +239,7 @@ class HTMLMeta {
      * 
      * @static
      * @access  protected
-     * @since   0.1.5-beta
+     * @since   LBF 0.1.5-beta
      */
 
     protected static function html_tag_close( string $tag, int $count, ?string $comment ): string {

--- a/src/HTML/Scripts.php
+++ b/src/HTML/Scripts.php
@@ -12,67 +12,54 @@ use LBF\Auth\Hash;
  * @author  Gareth Palmer  [Github & Gitlab /projector22]
  * 
  * @since   LRS 3.12.5
- * @since   LRS 3.28.0  Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
- *                  Namespace changed from `Framework` to `LBF`.
+ * @since   LRS 3.28.0      Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
+ *                          Namespace changed from `Framework` to `LBF`.
+ * @since   LBF 0.1.6-beta  Added extension `HTMLMeta`.
  */
 
-class Scripts {
-
-    /**
-     * Whether or not to echo or return the html element
-     * 
-     * @var    boolean     $echo   Default: true
-     * 
-     * @access  public
-     * @since   LRS 3.12.5
-     */
-
-    public static bool $echo = true;
+class Scripts extends HTMLMeta {
 
     /**
      * Draw a script onto the screen
      * 
-     * @param   string  $script Any kind of JavaScript or JS function call
-     * @param   string  $src    An src element on the <script> tag
-     *                          Default: null
+     * @param   string      $script Any kind of JavaScript or JS function call
+     * @param   string|null $src    An src element on the <script> tag
+     *                              Default: null
      * 
-     * @return  string  The formed script element
+     * @return  string
      * 
+     * @static
      * @since   LRS 3.7.6
      * @since   LRS 3.12.5  Moved from PageElements to Framework\HTML\Scripts. Added return & param $src
      */
 
-    public static function script( string $script, ?string $src = null ) {
+    public static function script( string $script, ?string $src = null ): string {
         $add_src = is_null( $src ) ? '' : " src='{$src}'";
         $element = "<script{$add_src}>{$script}</script>";
-        if ( self::$echo ) {
-            echo $element;
-        } else {
-            return $element;
-        }
+        self::handle_echo( $element );
+        return $element;
     }
 
 
     /**
      * Draw a script onto the screen, with type = module
      * 
-     * @param   string  $script Any kind of JavaScript or JS function call
-     * @param   string  $src    An src element on the <script> tag
-     *                          Default: null
+     * @param   string      $script Any kind of JavaScript or JS function call
+     * @param   string|null $src    An src element on the <script> tag
+     *                              Default: null
      * 
-     * @return  string  The formed script element
+     * @return  string
      * 
+     * @static
+     * @access  public
      * @since   LRS 3.13.0
      */
 
-    public static function script_module( $script, $src = null ) {
+    public static function script_module( string $script, ?string $src = null ): string {
         $add_src = is_null( $src ) ? '' : " src='{$src}'";
         $element = "<script{$add_src} type='module'>{$script}</script>";
-        if ( self::$echo ) {
-            echo $element;
-        } else {
-            return $element;
-        }
+        self::handle_echo( $element );
+        return $element;
     }
 
 
@@ -81,18 +68,17 @@ class Scripts {
      * 
      * @param   string  $src    Path to the JS file
      * 
-     * @return  string  The  formed script element
+     * @return  string
      * 
+     * @static
+     * @access  public
      * @since   LRS 3.12.5
      */
 
-    public static function script_loader( string $src ) {
+    public static function script_loader( string $src ): string {
         $element = "<script src='{$src}'></script>";
-        if ( self::$echo ) {
-            echo $element;
-        } else {
-            return $element;
-        }
+        self::handle_echo( $element );
+        return $element;
     }
 
 
@@ -101,23 +87,22 @@ class Scripts {
      * 
      * @param   string  $src    Path to the JS file
      * 
-     * @return  string  The  formed script element
+     * @return  string
      * 
+     * @static
+     * @access  public
      * @since   LRS 3.13.0
      */
 
-    public static function script_module_loader( string $src ) {
+    public static function script_module_loader( string $src ): string {
         $element = "<script src='{$src}' type='module'></script>";
-        if ( self::$echo ) {
-            echo $element;
-        } else {
-            return $element;
-        }
+        self::handle_echo( $element );
+        return $element;
     }
 
 
     /**
-     * Draw an inline Javascript Alert
+     * Draw an inline Javascript Alert.
      * 
      * @param   string  $text   The text of the alert
      * 
@@ -136,12 +121,13 @@ class Scripts {
      * Credit to:
      * @link https://clipboardjs.com/
      * 
+     * @static
      * @access  public
      * @since   LRS 3.1.0
      * @since   LRS 3.12.5  Moved from PageElements to Framework\HTML\Scripts
      */
 
-    public static function clipboardButton( string $id = '.btn' ) {
+    public static function clipboardButton( string $id = '.btn' ): void {
         self::script_loader( 'src/js/thirdparty/clipboard.min.js' );
         self::script( "const clipboard = new ClipboardJS('{$id}');" );
     }
@@ -155,6 +141,7 @@ class Scripts {
      * @param   int     $keycode    The key to be monitored, Default: 13 (Enter)
      * @param   boolean $do_nothing Instruction to do nothing when the key is pressed
      * 
+     * @static
      * @access  public
      * @since   LRS 3.2.2
      * @since   LRS 3.4.5   $do_nothing added
@@ -169,7 +156,7 @@ class Scripts {
                     event.preventDefault();
                 }
             });" );
-    
+
         } else {
             self::script( "var input = document.getElementById('$input');
             input.addEventListener('keyup', function(event) {
@@ -187,6 +174,7 @@ class Scripts {
      * 
      * @param   int  $keycode    The key to be monitored, Default: 13 (Enter)
      * 
+     * @static
      * @access  public
      * @since   LRS 3.2.2
      * @since   LRS 3.12.5  Moved from PageElements to Framework\HTML\Scripts
@@ -213,6 +201,7 @@ class Scripts {
      * @param   string  $content        The content to put in the area being hidden.
      *                                  Default: ''
      * 
+     * @static
      * @access  public
      * @since   LRS 3.4.1
      * @since   LRS 3.7.0   Added @param $function_name - Reworked logic to use MutationObserver
@@ -242,11 +231,12 @@ class Scripts {
      * 
      * @param   string  $desired_function   The name of the desired Javascript function
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.0
      * @since   LRS 3.12.5  Moved from PageElements to Framework\HTML\Scripts
      */
-    
+
     public static function insert_keyboard_shortcuts( string $desired_function ): void {
         /**
          * @see src\js\lib\keyboard_shortcuts.js
@@ -264,6 +254,7 @@ class Scripts {
     /**
      * Draw the shift multiselect onLoad script
      * 
+     * @static
      * @access  public
      * @since   LRS 3.6.4
      * @since   LRS 3.12.5  Moved from PageElements to Framework\HTML\Scripts

--- a/src/HTML/Table.php
+++ b/src/HTML/Table.php
@@ -16,7 +16,7 @@ use LBF\HTML\HTML;
  * 
  * @since   LRS 3.15.5
  * @since   LRS 3.28.0  Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
- *                  Namespace changed from `Framework` to `LBF`.
+ *                      Namespace changed from `Framework` to `LBF`.
  */
 
 class Table {
@@ -119,7 +119,7 @@ class Table {
      */
 
     public bool $edit_link;
-    
+
     /**
      * Draw the table as a full width table
      * 
@@ -271,9 +271,9 @@ class Table {
         if ( isset( $params['id'] ) ) {
             throw new Exception( "You cannot set an id for a Table Row" );
         }
-        
+
         $class = 'standard_row';
-        
+
         if ( !isset( $params['heading'] ) || $params['heading'] == false ) {
             $params['id'] = $this->table_id . '--row_' . $this->row_index;
             $class .= ' body_row';
@@ -286,7 +286,7 @@ class Table {
         if ( isset( $params['highlight'] ) && $params['highlight'] == true ) {
             $class .= ' highlight_empty';
         }
-        
+
         if ( isset( $params['class'] ) ) {
             $params['class'] = "{$class} {$params['class']}";
         } else {
@@ -334,7 +334,7 @@ class Table {
      * 
      * @param   array   $heading    The headings to place on top of the table
      *                              Default: []
-     * @param   array   $params     Params to add to the cell. 
+     * @param   array   $params     Params to add to the cell.
      *                              Can contain standard attributes like class or name as well as the following:
      *                              - 'alignment' ['L', 'C', 'R']
      *                              Default: []
@@ -345,7 +345,7 @@ class Table {
 
     private function headings( array $headings = [], array $params = [] ): void {
         $this->row_start( [
-            'class'   => 'table_header', 
+            'class'   => 'table_header',
             'heading' => true
         ] );
         if ( $this->select_checkbox ) {
@@ -387,7 +387,7 @@ class Table {
      * A table cell <td></td>.
      * 
      * @param   mixed   $content    The content of the cell.
-     * @param   array   $params     Params to add to the cell. 
+     * @param   array   $params     Params to add to the cell.
      *                              Can contain standard attributes like class or name as well as the following:
      *                              - 'alignment' ['L', 'C', 'R']
      *                              Default: []
@@ -411,7 +411,7 @@ class Table {
         $tdh = isset ( $params['heading'] ) && $params['heading'] == true ? 'th' : 'td';
 
         $cell = "<{$tdh}";
-        
+
         foreach ( $params as $key => $value ) {
             if ( in_array ( $key, self::SKIP_KEYS ) ) {
                 continue;
@@ -431,7 +431,7 @@ class Table {
      * Insert a cell edit link.
      * 
      * @param   string  $href   The link to navigate to. Something like '?p=example&x=y'
-     * @param   array   $params     Params to add to the cell. 
+     * @param   array   $params     Params to add to the cell.
      *                              Can contain standard attributes like class or name as well as the following:
      *                              - 'alignment' ['L', 'C', 'R']
      *                              Default: []
@@ -486,7 +486,7 @@ class Table {
             throw new Exception( "You cannot set an id for a Table Cell" );
         }
         $params['id'] = $this->get_cell_id();
-        
+
         $input = "<input type='hidden' value='{$value}'";
         foreach ( $params as $key => $value ) {
             $input .= " {$key}='{$value}'";
@@ -653,7 +653,7 @@ class Table {
  * 
  * As a future idea:
  * 
- * Consolidate all the search methods into this class. Have them as as callable methods with 
+ * Consolidate all the search methods into this class. Have them as as callable methods with
  * automatic JS included, pointing back to a single script in the js
  * class table_filter class.
  * 

--- a/src/HTML/Table.php
+++ b/src/HTML/Table.php
@@ -2,7 +2,6 @@
 
 namespace LBF\HTML;
 
-use \Exception;
 use LBF\Errors\InvalidInputException;
 use LBF\HTML\JS;
 use LBF\HTML\Form;
@@ -463,15 +462,12 @@ class Table {
             $params['class'] .= ' edit_link_width';
         }
 
-        // $hold = HTML::temporary_change_echo( false );
         $link = HTML::a( [
             'href'    => $href, 
             'text'    => 'Edit',
             'new_tab' => true,
             'echo'    => false,
         ] );
-        // // $link = HTML::link( $href, 'Edit', ['new_tab' => true ] );
-        // HTML::restore_origonal_echo( $hold );
         $cell = "<td";
         foreach ( $params as $key => $value ) {
             $cell .= " {$key}='{$value}'";
@@ -491,13 +487,15 @@ class Table {
      * 
      * @return  self  $this
      * 
+     * @throws  InvalidInputException   If trying to set an id of a table cell.
+     * 
      * @access  public
      * @since   LRS 3.15.5
      */
 
     public function hidden_data( mixed $value, array $params = [] ): self {
         if ( isset( $params['id'] ) ) {
-            throw new Exception( "You cannot set an id for a Table Cell" );
+            throw new InvalidInputException( "You cannot set an id for a Table Cell" );
         }
         $params['id'] = $this->get_cell_id();
 

--- a/src/HTML/Table.php
+++ b/src/HTML/Table.php
@@ -454,10 +454,9 @@ class Table {
             $params['class'] .= ' edit_link_width';
         }
 
-        $hold = HTML::$echo;
-        HTML::$echo = false;
+        $hold = HTML::temporary_change_echo( false );
         $link = HTML::link( $href, 'Edit', ['new_tab' => true ] );
-        HTML::$echo = $hold;
+        HTML::restore_origonal_echo( $hold );
         $cell = "<td";
         foreach ( $params as $key => $value ) {
             $cell .= " {$key}='{$value}'";
@@ -511,8 +510,7 @@ class Table {
      */
 
     private function select_checkbox( bool $select_all_checkbox = false, bool $disabled = false  ): void {
-        $hold = Form::$echo;
-        Form::$echo = false;
+        $hold = Form::temporary_change_echo( false );
         if ( $select_all_checkbox ) {
             $checkboxs = Form::checkbox( [
                 'id'        => "{$this->table_id}_select_all",
@@ -538,7 +536,7 @@ class Table {
                 'container' => ['overwrite' => true],
             ] ), ['class' => 'selectable_checkbox_width'] );
         }
-        Form::$echo = $hold;
+        Form::restore_origonal_echo( $hold );
     }
 
 

--- a/src/HTML/Table.php
+++ b/src/HTML/Table.php
@@ -3,6 +3,7 @@
 namespace LBF\HTML;
 
 use \Exception;
+use LBF\Errors\InvalidInputException;
 use LBF\HTML\JS;
 use LBF\HTML\Form;
 use LBF\HTML\HTML;
@@ -189,13 +190,15 @@ class Table {
      * 
      * @return  self  $this
      * 
+     * @throws  InvalidInputException   If trying to set an id of the table.
+     * 
      * @access  public
      * @since   LRS 3.15.5
      */
 
     public function table_start( array $headings = [], array $params = [] ): self {
         if ( isset( $params['id'] ) ) {
-            throw new Exception( "You cannot set an id for a Table" );
+            throw new InvalidInputException( "You cannot set an id for a Table" );
         }
         $params['id'] = $this->table_id . '_table';
 
@@ -263,13 +266,15 @@ class Table {
      * 
      * @return  self  $this
      * 
+     * @throws  InvalidInputException   If trying to set an id of a table row.
+     * 
      * @access  public
      * @since   LRS 3.15.5
      */
 
     public function row_start( array $params = [] ): self {
         if ( isset( $params['id'] ) ) {
-            throw new Exception( "You cannot set an id for a Table Row" );
+            throw new InvalidInputException( "You cannot set an id for a Table Row" );
         }
 
         $class = 'standard_row';
@@ -394,13 +399,15 @@ class Table {
      * 
      * @return  self  $this
      * 
+     * @throws  InvalidInputException   If trying to set an id of a table cell.
+     * 
      * @access  public
      * @since   LRS 3.15.5
      */
 
     public function cell( mixed $content, array $params = [] ): self {
         if ( isset( $params['id'] ) ) {
-            throw new Exception( "You cannot set an id for a Table Cell" );
+            throw new InvalidInputException( "You cannot set an id for a Table Cell" );
         }
         if ( !isset ( $params['heading'] ) || $params['heading'] == false ) {
             $params['id'] = $this->get_cell_id();
@@ -438,13 +445,15 @@ class Table {
      * 
      * @return  self  $this
      * 
+     * @throws  InvalidInputException   If trying to set an id of a table cell.
+     * 
      * @access  public
      * @since   LRS 3.15.5
      */
 
     public function cell_edit_link( string $href, array $params = [] ): self {
         if ( isset( $params['id'] ) ) {
-            throw new Exception( "You cannot set an id for a Table Cell" );
+            throw new InvalidInputException( "You cannot set an id for a Table Cell" );
         }
         $params['id'] = $this->get_cell_id();
         $params = $this->set_vertical_lines( $params );
@@ -454,9 +463,15 @@ class Table {
             $params['class'] .= ' edit_link_width';
         }
 
-        $hold = HTML::temporary_change_echo( false );
-        $link = HTML::link( $href, 'Edit', ['new_tab' => true ] );
-        HTML::restore_origonal_echo( $hold );
+        // $hold = HTML::temporary_change_echo( false );
+        $link = HTML::a( [
+            'href'    => $href, 
+            'text'    => 'Edit',
+            'new_tab' => true,
+            'echo'    => false,
+        ] );
+        // // $link = HTML::link( $href, 'Edit', ['new_tab' => true ] );
+        // HTML::restore_origonal_echo( $hold );
         $cell = "<td";
         foreach ( $params as $key => $value ) {
             $cell .= " {$key}='{$value}'";

--- a/src/HTML/Terminal.php
+++ b/src/HTML/Terminal.php
@@ -13,7 +13,7 @@ use LBF\HTML\HTML;
  * 
  * @since   LRS 3.27.0
  * @since   LRS 3.28.0  Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
- *                  Namespace changed from `Framework` to `LBF`.
+ *                      Namespace changed from `Framework` to `LBF`.
  */
 
 class Terminal {
@@ -84,7 +84,7 @@ class Terminal {
         if ( $open ) {
             $class .= ' feedback_console_height';
         }
-        
+
         HTML::div( [
             'class'                => $class,
             'id'                   => $this->console_id,
@@ -99,7 +99,7 @@ class Terminal {
 
         HTML::close_div(); // feedback_console
         // HTML::div(); // Options
-        
+
         /**
          * @todo    Create a `src/Framework/HTML/Forms.php` Form for this type of input.
          * 
@@ -108,7 +108,7 @@ class Terminal {
          * @since   LRS 3.27.0
          */
         // echo "<input type='range' min='1', max='100' value='90' id='terminal_opacity.{$this->console_id}' name='terminal_opacity'>";
-        
+
         // HTML::close_div();
     }
 

--- a/src/Tools/Files/FileSystem.php
+++ b/src/Tools/Files/FileSystem.php
@@ -2,7 +2,7 @@
 
 namespace LBF\Tools\Files;
 
-use \Exception;
+use Exception;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 
@@ -18,7 +18,7 @@ use RecursiveDirectoryIterator;
  * @since   LRS 3.4.0
  * @since   LRS 3.11.0  Moved to `Framework\Tools\FileSystem`.
  * @since   LRS 3.28.0  Seperated out of `Lourie Registration System` into `Lourie Basic Framework`.
- *                  Namespace changed from `Framework` to `LBF`.
+ *                      Namespace changed from `Framework` to `LBF`.
  */
 
 class FileSystem {
@@ -28,6 +28,7 @@ class FileSystem {
      * 
      * @var string  $last_error
      * 
+     * @static
      * @access  public
      * @since   LRS 3.15.4
      */
@@ -40,6 +41,7 @@ class FileSystem {
      * 
      * @var array   $all_errors     Default: []
      * 
+     * @static
      * @access  public
      * @since   LRS 3.15.4
      */
@@ -53,6 +55,7 @@ class FileSystem {
      * 
      * @return  string  Octal file permissions, eg. 0775
      * 
+     * @static
      * @access  public
      * @since   LRS 3.7.0
      */
@@ -69,6 +72,7 @@ class FileSystem {
      * 
      * @return  string  string with slashes corrected
      * 
+     * @static
      * @access  public
      * @since   LRS 3.7.0
      */
@@ -95,6 +99,7 @@ class FileSystem {
      * 
      * @return  boolean     Success or failure.
      * 
+     * @static
      * @access  public
      * @since   LRS 3.15.4
      */
@@ -165,6 +170,7 @@ class FileSystem {
      * 
      * @return  boolean
      * 
+     * @static
      * @access  public
      * @since   LRS 3.17.3
      */
@@ -196,6 +202,7 @@ class FileSystem {
      * 
      * @return  boolean
      * 
+     * @static
      * @access  public
      * @since   LRS 3.17.3
      */
@@ -218,6 +225,7 @@ class FileSystem {
      * 
      * @return  boolean
      * 
+     * @static
      * @access  public
      * @since   LRS 3.17.3
      */
@@ -234,6 +242,7 @@ class FileSystem {
      * 
      * @return  boolean
      * 
+     * @static
      * @access  public
      * @since   LRS 3.19.6
      */
@@ -268,6 +277,7 @@ class FileSystem {
      * 
      * @return  boolean
      * 
+     * @static
      * @access  public
      * @since   LRS 3.26.4
      */
@@ -295,6 +305,7 @@ class FileSystem {
      * 
      * @return  array
      * 
+     * @static
      * @access  public
      * @since   LRS 3.21.1
      */
@@ -311,6 +322,23 @@ class FileSystem {
         }
         sort( $files );
         return $files;
+    }
+
+
+    /**
+     * Returns if the file exists.
+     * 
+     * @param   string  $path   Path to the file to be tested.
+     * 
+     * @return  boolean
+     * 
+     * @static
+     * @access  public
+     * @since   LBF 0.1.6-beta
+     */
+
+    public static function file_exists( string $path ): bool {
+        return file_exists( $path );
     }
 
 }

--- a/src/css/lib/template.css
+++ b/src/css/lib/template.css
@@ -38,25 +38,6 @@ aside::-webkit-scrollbar {
     display: none;
 }
 
-header {
-    grid-area: header;
-    height: 50px;
-    max-height: 50px;
-    font-size: 20px;
-    display: flex;
-    justify-content: center;
-    align-items: stretch;
-    box-shadow: 6px 4px 18px -2px rgba(41, 41, 46, 0.14);
-    margin-bottom: 5px;
-    max-width: 100vw;
-}
-
-header a:link,
-header a:visited {
-    text-decoration: none;
-    color: var(--default-text-colour);
-}
-
 main {
     grid-area: body;
     overflow: auto;


### PR DESCRIPTION
## Version 0.1.6-beta - 2022-09-14

### Added

- Added `Auth\LoginHandler`.
- Added new `HTMLElements` method `a` for inserting links.
- Added method `file_exists` to `FileSystem`.
- Added a tool for inline setting echo for the specific object being drawn. #23
- Added methods for more easily changing the value of `class::$echo`.
- Added Exception Class `MethodNotFound`.
- Added meta methods for rendering HTML elements and consolidated current methods into these methods. These methods are:
  - `html_element_container`.
  - `html_tag_open`.
  - `html_tag_close`.
  - `assign_key_values`.

### Changed

- Extended the following to `HTML\HTMLMeta`: #23
  - `HTML\Buttons`
  - `HTML\Draw`
  - `HTML\Forms`
  - `HTMLElements`
  - `HTML\Scripts`

### Fixed

- Fixed a bug with `HTML::p_container`.
- Fixed a bug with header styles.

### Deprecated

- `HTMLElements` method `link`.

### Issues Closed

- #23