### PR TITLE
47 fix file permissions bug in logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added error `LogPathNotSet`.
 
+### Changed
+
+- Revamped ConnectMySQL so that the logging path is not set by default, and if one is not explicitly set, an exception is thrown. #47
+
 ### Issues Closed
 
 - #47 WIP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## Version 0.3.3-beta - UNRELEASED
+
+### Added
+
+- Added error `LogPathNotSet`.
+
+### Issues Closed
+
+- #47 WIP
+
+---
+
 ## Version 0.3.2-beta - 2022-10-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Version 0.3.3-beta - UNRELEASED
+## Version 0.3.3-beta - 2022-10-25
 
 ### Added
 
@@ -10,9 +10,16 @@
 
 - Revamped ConnectMySQL so that the logging path is not set by default, and if one is not explicitly set, an exception is thrown. #47
 
+### Packages Updated
+
+| Package | Old | New |
+| ------- | --- | --- |
+| phpmailer | v6.6.4 | v6.6.5 |
+| PHP Debuggin Tool | 1.0.5 | 1.0.7 |
+
 ### Issues Closed
 
-- #47 WIP
+- #47
 
 ---
 

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,3 +1,2 @@
 *
 !.gitignore
-!logs

--- a/bin/logs/.gitignore
+++ b/bin/logs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/composer.lock
+++ b/composer.lock
@@ -349,5 +349,5 @@
         "php": ">=8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Db/ConnectMySQL.php
+++ b/src/Db/ConnectMySQL.php
@@ -1502,21 +1502,16 @@ class ConnectMySQL {
      * Log SQL queries.
      * 
      * @param   mixed       $data       The data to write.
-     * @param   string|null $log_path   Overwrite the path to log the data.
      * 
      * @throws  LogPathNotSet       If no logging path is set.
      * @throws  FileNotWriteable    If the log file is read only.
      * 
      * @access  private
      * @since   LRS 3.23.3
-     * @since   LBF 0.3.3-beta  Added param `$log_path`.
      */
 
-    private function log_sql( mixed $data, ?string $log_path = null ): void {
+    private function log_sql( mixed $data ): void {
         $timestamp = date( 'Y-m-d G:i:s' );
-        if ( !is_null( $log_path ) ) {
-            $this->set_log_path( $log_path );
-        }
         if ( is_null( $this->log_path ) ) {
             throw new LogPathNotSet( "Please set a value for logging an SQL result." );
         }

--- a/src/Errors/Log/LogPathNotSet.php
+++ b/src/Errors/Log/LogPathNotSet.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LBF\Errors\Log;
+
+use LBF\Errors\Meta\ExceptionMeta;
+
+/**
+ * Error page for handling errors that occure when the path to log files is not set.
+ * 
+ * use LBF\Errors\Log\LogPathNotSet;
+ * 
+ * @author  Gareth Palmer   [Github & Gitlab /projector22]
+ * @since   LBF 0.3.3-beta
+ */
+
+class LogPathNotSet extends ExceptionMeta {}


### PR DESCRIPTION
# Version 0.3.3-beta - 2022-10-25

## Added

- Added error `LogPathNotSet`.

## Changed

- Revamped ConnectMySQL so that the logging path is not set by default, and if one is not explicitly set, an exception is thrown. #47

## Packages Updated

| Package | Old | New |
| ------- | --- | --- |
| phpmailer | v6.6.4 | v6.6.5 |
| PHP Debuggin Tool | 1.0.5 | 1.0.7 |

## Issues Closed

- #47